### PR TITLE
Autodesk: Text Updates

### DIFF
--- a/proposals/text/README.md
+++ b/proposals/text/README.md
@@ -19,7 +19,7 @@ The text properties are commonly called text style.
 |  Bold  |![](bold.jpg)| Bold is the property of a font. |
 |  Italic  |![](italic.jpg)| Italic is the property of a font. |
 |  Weight  |![](weight.jpg)| For some font library such as GDI, you can define the weight of the stroke. But Freetype doesn't have this feature. |
-|  Height  |![](Size.jpg)| For some font, the appearance of a character may change when height of the character changes. So scale matrix can not be used to implement text height. |
+|  Height  |![](Size.jpg)| For some font, the appearance of a character may change when height of the character changes. |
 |  Width factor  |![](width.jpg)| The factor will be multiplied to the width of each character, including the white space. |
 |  Oblique  |![](oblique.jpg)| Oblique is a transform of the text mesh. It is different from italic, which is not a transform, but a property of font. |
 |  Character spacing  |![](characterSpace.jpg)| Character spacing is the space between characters. |
@@ -37,7 +37,7 @@ Single line single style text can have special layout.
 
 | property name |   example   |  comment  |
 |:--------:|:---------:|:-----------|
-|  Direction  |![](direction.jpg)| Some languages are written from left to right, while others are written right to left, such as Arabic. The Chinese characters can be written from left to right or right to left. |
+|  Direction  |![](direction.jpg)| Some languages are written from left to right, while others are written right to left, such as Arabic. The Chinese characters can be written from left to right, from right to left and from top to bottom. |
 
 </details>
 
@@ -73,12 +73,14 @@ This is a picture which illustrates what are the column margins and paragraph in
 The work proposed here aims to tackle all of these properties. Those not listed can be considered in future works.
 
 ### Rendering technique
-There are already many different techniques which can display the text on screen. One common technique is to directly use font engine such as GDI or Freetype to generate a texture for the text, and then render the texture on the screen. Another technique is to get the control points of the curves which form the outline of the characters, and then render the curves on the screen. Different techniques may have different quality and performance. 
+There are already many different techniques which can display the text on screen. One commonly used technique is MSDF, that generate the multi-channel signed distance field for each character, and use it to reconstruct the shape of the glyph. Another technique is to get the control points of the curves which form the outline of the characters, and then render the curves on the screen. Different techniques may have different quality and performance. 
 
 # The single line single style text schema
 A new primitive SimpleText is added, which inherits from Gprim. It inherits properties from Gprim.
 
-We also have 3 schemas that the SimpleText primitive can bind. They are TextStyle, TextLayout, and TextRenderingTechnique. All the text schemas are in the UsdText domain.
+We also have 2 schemas that the SimpleText primitive can bind. They are TextStyle and TextLayout. All the text schemas are in the UsdText domain. We have default value for TextLayout, so SimpleText primitive doesn't need to bind to TextLayout. But one SimpleText primitive must bind to a TextStyle.
+
+The SimpleText primitive also must bind to a material. Please see "The Rprims and the shader for Text" part and "UsdImagingTextRenderer" part below.
 
 ### Properties inherited from Gprim
 - doublesided
@@ -96,17 +98,16 @@ The primvars:displaycolor and the primvars:displayopacity will be the color and 
 - textData. The text data is a UTF-8 string. This property must be specified for SimpleText.
 - primvars:backgroundColor. The color of the background. By default there is no background color. (Currently this not supported in our implementation. Will be implemented in the future.)
 - primvars:backgroundOpacity. The opacity of the background. By default there is no background opacity. (Currently this not supported in our implementation. Will be implemented in the future.)
-- textMetricsUnit. The unit for text metrics, such as text height. It is a string token, which could be "pixel", "publishingPoint" or "worldUnit". By default it is "worldUnit". If textMetricsUnit is "pixel", the unit of text metrics will be the same as a pixel in the framebuffer. If textMetricsUnit is "publishingPoint", the unit will be the same as desktop publishing point, or 1/72 of an inch on a screen's physical display. If textMetricsUnit is "worldUnit", the unit will be the same as the unit of the world space.
-
-If the text primitive has billboard, the textMetricsUnit can only be "pixel" or "publishingPoint". Otherwise, the textMetricsUnit can only be "worldUnit".
+- textMetricsUnit. The unit for text metrics, such as text height. It is a string token, which could be "pixel", "publishingPoint" or "worldUnit". By default it is "worldUnit". If textMetricsUnit is "pixel", the unit of text metrics will be the same as a pixel in the framebuffer. If textMetricsUnit is "publishingPoint", the unit will be the same as desktop publishing point, or 1/72 of an inch on a screen's physical display. If textMetricsUnit is "worldUnit", the unit will be the same as the unit of the world space. If the text primitive has billboard, the textMetricsUnit can only be "pixel" or "publishingPoint". Otherwise, the textMetricsUnit can only be "worldUnit".
+- renderer. The name or id of the text renderer. It is a string. By default it is empty. Please see "UsdImagingTextRenderer" part below.
 
 ### Properties of TextStyle
-The style for the text is included in a separate class named TextStyle. A SimpleText primitive must be bound with a TextStyle. 
+The style for the text is included in a separate class named TextStyle. A SimpleText primitive must bind to a TextStyle. 
 
 Currently the TextStyle class includes the following properties:
 
-- typeface. The string for the font name. This property must be specified for TextStyle.
-- textHeight. An int value represents the height of the text. This property must be specified for TextStyle. The unit is textMetricsUnit. If you want to get a float text height, you need to use a scale matrix.
+- typeface. The string for the font name. This property must be specified for TextStyle. There is no default value.
+- textHeight. An int value represents the height of the text. This property must be specified for TextStyle. There is no default value. The unit is textMetricsUnit. If you want to get a float text height, you need to use a scale matrix.
 - bold. A boolean value. By default it is false.
 - italic. A boolean value. By default it is false.
 - weight. An int value for font weight. By default, it is 0, which means the weight value is ignored, and the bold property will work. If it is not 0, we will ignore the bold property. 
@@ -114,25 +115,18 @@ We use the definition of weight in GDI on Windows. That is, the weight value is 
 - obliqueAngle. A float value for the skew angle between the character's left line and the vertical axis. The unit is degree. By default it is zero.
 - textWidthFactor. A float value for the scale factor of the character width. By default it is 1.0.
 - charSpacing. A float value. This is defined as the scale factor of the character width plus the character space. By default it is 1.0.
-- underlineType. This is a string token. "none" means there is no underline. "normal" means the underline is a normal line. You can define other type of underline. By default it is "none".
-- overlineType. This is a string token. "none" means there is no overline. "normal" means the overline is a normal line. You can define other type of overline. By default it is "none".
-- strikethroughType. This is a string token. "none" means there is no strikethrough. "normal" means the strikethrough is a normal line. "double" means the strikethrough is double lines. You can define other type of strikethrough. By default it is "none".
+- underlineType. This is a string token, which could be "none" or "normal". "none" means there is no underline. "normal" means the underline is a normal line. You can define other type of underline. By default it is "none".
+- overlineType. This is a string token, which could be "none" or "normal". "none" means there is no overline. "normal" means the overline is a normal line. You can define other type of overline. By default it is "none".
+- strikethroughType. This is a string token, which could be "none", "normal" or "doubleLines". "none" means there is no strikethrough. "normal" means the strikethrough is a normal line. "doubleLines" means the strikethrough is double lines. You can define other type of strikethrough. By default it is "none".
 
 ### Properties of TextLayout
 The layout of the text is defined in a separate class named TextLayout. A SimpleText primitive doesn't need to have a TextLayout. In that case, all the properties are in default value.
 
 Currently the TextLayout class includes the following properties:
 
-- direction. This is a string token. By default it is "default", which means the direction is decided by the script of the text data. "leftToRight" means the text is written from left to right. "rightToLeft" means the text is written from right to left. "topToBottom" means the text is written from top to bottom. "bottomToTop" means the text is written from bottom to top. (Currently in our implementation the direction will always be "default". The other settings will not take effect, but will be implemented in the future.)
+- direction. This is a string token, which could be "defaultDir", "leftToRight", "rightToLeft", "topToBottom" or "bottomToTop". By default it is "defaultDir", which means the direction is decided by the script of the text data. "leftToRight" means the text is written from left to right. "rightToLeft" means the text is written from right to left. "topToBottom" means the text is written from top to bottom. "bottomToTop" means the text is written from bottom to top. (Currently in our implementation the direction will always be "defaultDir". The other settings will not take effect, but will be implemented in the future.)
 
-### Properties of TextRenderingTechnique
-The text rendering technique is defined in a seperate class named TextRenderingTechnique. A SimpleText primitive doesn't need to have a TextRenderingTechnique. In that case, the technique is the default technique.
-
-Currently the TextRenderingTechnique includes the following properties:
-
-- technique. The technique is a string token. It could be either "rasterGlyph" or "exactCurveRender". By default it is "exactCurveRender". "rasterGlyph" means we will create a rectangle for each character and will generate the texture for each character using a font library such as FreeType. "exactCurveRender" means we will get control points of the character from font library and create the curves that form the shape. (Currently the implementation only supports "exactCurveRender". The setting "rasterGlyph" be implemented in the future.)
-
-By including the SimpleText, TextStyle, TextLayout and TextRenderingTechnique class you can get a complete text primitive which can be rendered in HdStorm.
+By including the SimpleText, TextStyle, and TextLayout class you can get a complete text primitive which can be rendered in HdStorm.
 
 You can add more properties. For example, you may add "points" property, which is directly set by the user rather than generated when we generate the rprim for text. 
 
@@ -141,14 +135,16 @@ TextStyleAPI is a new API schema which is for applying TextStyle to a prim. It i
 
 TextLayoutAPI is a new API schema which is for applying TextLayout to a prim. It is a single-apply API schema.
 
-TextRenderingTechniqueAPI is a new API schema which is for applying TextRenderingTechnique to a prim. It is a single-apply API schema.
-
-One TextStyle can be applied to multiple different SimpleText primitive. The same for TextLayout and TextRenderingTechnique.
+One TextStyle can be applied to multiple different SimpleText primitive. The same for TextLayout.
 
 # The multi-line multi-style text schema
 A new primitive MarkupText is added, which inherits from Gprim. It inherits properties from Gprim.
 
 We also have 2 schemas that the MarkupText primitive can bind. They are ParagraphStyle, and ColumnStyle. All the text schemas are in the UsdText domain.
+
+The MarkupText can (but not must) bind to the TextStyle, which will be the default style for the text. The style defined in the markup will override the default text style. 
+
+The MarkupText primitive also must bind to a material. Please see "The Rprims and the shader for Text" part and "UsdImagingTextRenderer" part below.
 
 ### Properties inherited from Gprim
 - doublesided
@@ -163,13 +159,12 @@ We also have 2 schemas that the MarkupText primitive can bind. They are Paragrap
 The primvars:displaycolor and the primvars:displayopacity will be the default color and opacity of the MarkupText. They can be override by the color and opacity value in the markup string.
 
 ### Properties specialized for MarkupText
-- markup. The text data could be interpreted as a markup string. This must be specified for MarkupText.
+- markup. The text data could be interpreted as a markup string. There is no default value. This must be specified for MarkupText.
 - markupLanguage. It is a string token tells how the markup tags are interpreted. Currently we support "noMarkup" which is for plain text string, and "mtext" which is for MTEXT markups. By default it is "noMarkup".
 - primvars:backgroundColor. The color of the background. By default there is no background color. It can be overridden by the specified background color in the markup. (Currently this not supported in our implementation. Will be implemented in the future.)
 - primvars:backgroundOpacity. The opacity of the background. By default there is no background opacity. The background is completely transparent. It can be overridden by the specified background color in the markup. (Currently this not supported in our implementation. Will be implemented in the future.)
-- textMetricsUnit. The unit for text metrics, such as text height. It is a string token, which could be "pixel", "publishingPoint" or "worldUnit". By default it is "worldUnit". If textMetricsUnit is "pixel", the unit of text metrics will be the same as a pixel in the framebuffer. If textMetricsUnit is "publishingPoint", the unit will be the same as desktop publishing point, or 1/72 of an inch on a screen's physical display. If textMetricsUnit is "worldUnit", the unit will be the same as the unit of the world space.
-
-If the text primitive has billboard, the textMetricsUnit can only be "pixel" or "publishingPoint". Otherwise, the textMetricsUnit can only be "worldUnit".
+- textMetricsUnit. The unit for text metrics, such as text height. It is a string token, which could be "pixel", "publishingPoint" or "worldUnit". By default it is "worldUnit". If textMetricsUnit is "pixel", the unit of text metrics will be the same as a pixel in the framebuffer. If textMetricsUnit is "publishingPoint", the unit will be the same as desktop publishing point, or 1/72 of an inch on a screen's physical display. If textMetricsUnit is "worldUnit", the unit will be the same as the unit of the world space. If the text primitive has billboard, the textMetricsUnit can only be "pixel" or "publishingPoint". Otherwise, the textMetricsUnit can only be "worldUnit".
+- renderer. The name or id of the text renderer. It is a string. By default it is empty. Please see "UsdImagingTextRenderer" part below.
 
 ### Properties of ColumnStyle
 The column style is defined in a separate class named ColumnStyle. There will be at least one column for the text, and you can specify any count of columns. Each column must be related with one ColumnStyle. The MarkupText primitive will have relationships with the ColumnStyle. From the count of ColumnStyle that is related with the MarkupText, you will know how many columns the text has.
@@ -177,11 +172,11 @@ The column style is defined in a separate class named ColumnStyle. There will be
 The column style defined in the markup will override the related property in column style. The direction defined in the markup for each single-line single-style sub-string will override the related properties in column style.
 - columnWidth. A float value for width. Zero means that the column doesn't have constraint in width. By default it is zero. The unit is textMetricsUnit.
 - columnHeight. A float value for height. Zero means that the column doesn't have constraint in height. By default it is zero. The unit is textMetricsUnit.
-- offset. Two float values for the offset from the origin of the last column to the origin of this column. By default it is zero. The unit is textMetricsUnit.
+- offset. Two float values for the offset from the origin of the MarkupText to the origin of this column. By default the two floats are zero. The unit is textMetricsUnit.
 - margins. Four float values for the margins of the column. By default all the margins are zero. The unit is textMetricsUnit.
 - blockAlignment. The blockAlignment is the vertical alignment of the text. It is a string token, which could be "top", "center" and "bottom". By default it is "top".
-- direction. This is a string token. By default it is "default", which means the direction is decided by the script of the text data. "leftToRight" means the text is written from left to right. "rightToLeft" means the text is written from right to left. "topToBottom" means the text is written from top to bottom. "bottomToTop" means the text is written from bottom to top. (Currently in our implementation the direction will always be "default". The other settings will not take effect, but will be implemented in the future.)
-- lineFlowDirection. This is a string token. By default it is "topToBottom". "leftToRight" means the text lines are piled from left to right. "rightToLeft" means the text lines are piled from right to left. "topToBottom" means the text lines are piled from top to bottom. "bottomToTop" means the text lines are piled from bottom to top. (Currently in our implementation the flow direction will always be "topToBottom". The other settings will not take effect, but will be implemented in the future.)
+- direction. This is a string token, which could be "defaultDir", "leftToRight", "rightToLeft", "topToBottom" or "bottomToTop". By default it is "defaultDir", which means the direction is decided by the script of the text data. "leftToRight" means the text is written from left to right. "rightToLeft" means the text is written from right to left. "topToBottom" means the text is written from top to bottom. "bottomToTop" means the text is written from bottom to top. (Currently in our implementation the direction will always be "defaultDir". The other settings will not take effect, but will be implemented in the future.)
+- lineFlowDirection. This is a string token, which could be "leftToRight", "rightToLeft", "topToBottom" or "bottomToTop". By default it is "topToBottom". "leftToRight" means the text lines are piled from left to right. "rightToLeft" means the text lines are piled from right to left. "topToBottom" means the text lines are piled from top to bottom. "bottomToTop" means the text lines are piled from bottom to top. (Currently in our implementation the flow direction will always be "topToBottom". The other settings will not take effect, but will be implemented in the future.)
 
 "leftToRight" and "rightToLeft" direction are valid only when linesFlowDirection is "topToBottom" or "bottomToTop". "topToBottom" and "bottomToTop" direction are valid only when linesFlowDirection is "leftToRight" or "rightToLeft".
 
@@ -201,17 +196,13 @@ ParagraphStyle has the following properties:
 - firstLineIndent. It is an float value for the indent in the first line. By default it is zero. The unit is textMetricsUnit.
 - leftIndent. It is an float value for the indent on the left of the paragraph. By default it is zero. The unit is textMetricsUnit.
 - rightIndent. It is an float value for the indent on the right of the paragraph. By default it is zero. The unit is textMetricsUnit.
-- paragraphAlignment. A string token which could be "left", "center", "right", "justify", and "distributed". By default it is "LeftAlign".
+- paragraphAlignment. A string token which could be "left", "center", "right", "justify", and "distributed". By default it is "left".
 - paragraphSpace. A float value for the space after the paragraph and before the next paragraph. By default it is zero. The unit is textMetricsUnit.
 - tabstops. A paragraph could have several tabstops. Each tabstop has the below properties:
   - tabstopType. It is a string token which could be "leftTab", "rightTab", "centerTab", or "decimalTab". By default it is "leftTab".
   - position. It is an float value for the position of the tabstop. This must be specified for a tabstop. The unit is textMetricsUnit.
 - lineSpace. A float value for the line space in this paragraph. By default it is zero. The unit is textMetricsUnit.
-- lineSpaceType. This is a string token. By default it is "exactly", which means the lineSpace value is exactly the space between lines. The value can be "exactly", "atLeast" and "multiple".
-
-The MarkupText can also have relationship with the TextStyle, which will be the default style for the text. The style defined in the markup will override the default text style.
-
-You can also composite the TextRenderTechnique with the MarkupText, to define how to render the MarkupText. 
+- lineSpaceType. This is a string token, which could be "exactly", "atLeast" or "multiple". By default it is "exactly", which means the lineSpace value is exactly the space between lines.
 
 ### New API schema
 ColumnStyleAPI is a new API schema which is for applying ColumnStyle to a prim. It is a single-apply API schema.
@@ -221,38 +212,43 @@ ParagraphStyleAPI is a new API schema which is for applying ParagraphStyle to a 
 Like the TextStyle, one ColumnStyle or ParagraphStyle can be applied to multiple different SimpleText primitive.
 
 # The Rprims and the shader for Text
-HdStSimpleText and HdStMarkupText are added as the Rprim for text. The HdStMarkupText is not a composition of several HdStSimpleText. They have separate definitions. 
+HdStSimpleText and HdStMarkupText are added as the Rprim for text. The HdStMarkupText is not a composition of several HdStSimpleText. They have separate definitions. Each text Rprim will generate one draw item for the text primitive.
 
-For either "exactCurveRender" or "rasterGlyph" rendering technique, there will be a specific text shader. Both HdStSimpleText and HdStMarkupText will use the same shader.
+The underline, overline and strikethrough are specially handling. They are not included in the text draw item. For each line, we will generate a basisCurve draw item.
 
-The scene delegate or scene index must provide the geometry, indices and required textures.
-
-# The imaging adapter
-Currently there is the UsdImagingSimpleTextAdapter for the SimpleText primitive, and UsdImagingMarkupTextAdapter for the MarkupText primitive. They can read the properties and will generate the geometry, indices and texture for the text rprim according to the TextRenderingTechnique.
-
-For example, if the technique is "rasterGlyph", it will create a list of rectangles as the geometry, with each rectangle for one character.  Then it will generate the texture for each character from the font library, put the texture onto a texture atlas, and pass the texture path to the rprim. 
-
-The adapter may also generate line or curve rprims for underline, overline and strikethrough or an additional mesh rprims for background colors.
+There is also a specified text.glslfx for the text primitive. Both HdStSimpleText and HdStMarkupText will use this shader. The shader contains a full implementation of vertex shader, but in the fragment shader, it requires a function getOpacity. The getOpacity function should return the opacity of the pixel for a character glyph. This function must be implemented in a surface shader. As a result, both the SimpleText and MarkupText primitive must bind to a material, and the material should contain the surface shader that implement the getOpacity function. In common case, the surface shader should be provided by a UsdImagingTextRenderer. See "UsdImagingTextRenderer" part below. 
 
 # The utilities
-In our implementation, two utilities are added to help display the text. They are added as plugins. The imaging adapter will use the utilities to generate geometries and textures for the text.
+In our implementation, three utilities are added to help display the text. They are added as plugins.
 
-### The markup parser
-The markup parser is added to parse the markup string of the MarkupText Gprim. Providing the markup language, it can divide the string into substrings, and each substring will have a single style. It will also generate the paragraph style and column style if the markups contain the information.
+### The UsdImagingMarkupParser
+The UsdImagingMarkupParser plugin class is to parse the markup string of the MarkupText Gprim. Providing the markup language, it can divide the string into substrings, and each substring will have a single style. It will also generate the paragraph style and column style if the markups contain the information.
 
-In the implementation, the UsdImagingMarkupParser plugin class will provide the functionality of the markup parser. And we provide UsdImagingCommonParser as the default plugin.
+Currently there is no default implementation. 
 
-### The text library
-The text library is a wrapper of Freetype library, which can generate the texture or curve information for each character. The text library will also help do line break for a long string, and it can help do complex language analysis, and even do font substitution if a character can not be displayed with the current font.
+### The UsdImagingText
+The UsdImagingText plugin class is a wrapper of a font library such as FreeType. It can get the font information and character information. It can also do multilanguage handling. With these functionality, the UsdImagingText can generate the layout: for SimpleText, it is how each character is positioned and also the extent of the whole string; and for MarkupText, it can also do line break and handle the paragraph style and column style.
+
+The UsdImagingText can also get the control point of a character, or the rasterized image of a character using the font library. If you provide a UsdImagingTextRenderer to it, it can use the renderer to generate the final geometry, texture and also the texture coordinate for each character.
 
 The text library also provide utility functions such as get the path of the system font folder, get the extents of a certain text string before we generate layout for it and so on.
 
-In the implementation, the UsdImagingText plugin class will provide the functionality of the text library. And we provide UsdImagingCommonText as the default plugin. The plugin uses FreeType as the font engine below.
+Currently there is no default implementation. 
 
-### Multilanguage handling
-We are going to support most of the common languages and writing systems: western alphabets, CJK characters, and also complex scripts such as Arabic and Hebrew. If the current font can not support the character, you can use the FontSubstitution setting to automatically select a font which can display the character.
+### The UsdImagingTextRenderer
+The UsdImagingTextRenderer plugin class is to generate the rendering geometry, texture and texture coordinate for a character. It has an TextRendererInput, which could be the rasterized image of the character together with the dimension of the image, or the control points of the character. It will use a text rendering algorithm to generate the rendering information. 
 
-The support for complex script is only available on Windows now. (We will use harfbuzz to help itemize the complex script characters in the future.)
+The UsdImagingTextRenderer also should provide a surface shader, which implement the getOpacity function. The shader should be correspond to the rendering algorithm.
+
+The name of the UsdImagingTextRenderer should be put in the text primitive, and it must correspond to the material which is bound to the text primitive. If the "renderer" property is set to empty, we will use the first UsdImagingTextRenderer in the registry.
+
+Currently there is no default implementation. 
+
+# The imaging adapter
+Currently there is the UsdImagingSimpleTextAdapter for the SimpleText primitive, and UsdImagingMarkupTextAdapter for the MarkupText primitive. They can read the properties and will use the three plugins above to generate the geometry, indices and texture for the text rprim.
+
+# Multilanguage support
+The multilanguage support is handled in UsdImagingText plugin. This plugin has an API to return the scripts that it can support. And in this plugin, it could do some complex script shaping or layout generation if it supports the script.
 
 # Further extension
 Billboard text: Billboarding is a way of adding special transformations to a geometry - anchoring to the screen, scaling to the screen instead of the world, etc. When there is extension to enable billboarding for Gprims, as SimpleText and MarkupText are type of Gprims, billboarding will be automatically enabled for them.


### PR DESCRIPTION
### Description of Proposal

Update the proposal to reflect changes in the design. The TextRenderingTechnique schema is removed. Instead, we add a "renderer" property to the SimpleText and MarkupText primitive, which specify the name of the text renderer. The text primitive should also bind to a material, and the material should correspond to the text renderer.

Prior PR: https://github.com/PixarAnimationStudios/OpenUSD-proposals/pull/24 

### Supporting Materials

N/A

### Contributing

<!--
Please review the  [Contributing](https://graphics.pixar.com/usd/release/contributing_to_usd.html) page in the
documentation for the Supplemental Terms that apply to this repository.
Place an X in the box when you have reviewed and agree to the Supplemental Terms.
-->
- [X] I agree to and accept the [Supplemental Terms](https://graphics.pixar.com/usd/release/contributing_supplemental.html).
