### PR TITLE
Variant Set Metadata Proposal

### DIFF
--- a/proposals/variant_set_metadata/README.md
+++ b/proposals/variant_set_metadata/README.md
@@ -1,0 +1,130 @@
+# Variant Set Metadata
+
+Copyright &copy; 2024, NVIDIA Corporation, version 1.0
+
+Joshua Miller   
+Tyler Hubbard   
+Matthew Kuruc   
+
+## Contents
+
+- [Introduction](#introduction)
+- [Metadata in OpenUSD](#metadata-in-openusd)
+- [Metadata Fields](#core-metadata-fields)
+- [Custom Metadata Fields](#custom-metadata-fields)
+- [Metadata Value Resoltuion](#metadata-value-resolution)
+- [Example](#example)
+- [UsdVariantSet is not a UsdObject](#`UsdVariantSet`-is-not-a-usdobject)
+- [Stage Flattening](#stage-flattening)
+
+## Introduction
+
+Variants in OpenUSD are a powerful mechanism that allow authors to modify scene description and express opinions for a given prim. These modifications will ultimately contribute to the final result of a prim during composition. Prims, along with attributes and relationships, offer APIs for authoring additional information, referred to as metadata, to assist editors such as usdview. However, there are times when it is desirable to also author metadata about a variant set for similar reasons but there is no facility to do so.
+
+We propose adding the ability to author metadata on `UsdVariantSet` to support similar functionality available to UsdPrim, UsdAttribute and UsdRelationship. This metadata is intended to be used in editors to display information such as a nicely formatted name for the variant set or whether the variant set should be hidden in certain views. `UsdVariantSet` metadata will not affect the composition behavior for a UsdPrim, UsdAttribute or UsdRelationship on a UsdStage. 
+
+## Metadata in OpenUSD
+
+Metadata is a core feature of OpenUSD that is available to SdfLayer, UsdStage, UsdPrim and both subclasses of UsdProperty. UsdPrim and UsdProperty both derive from UsdObject which provides API for authoring and accessing metadata. Common examples of metadata available for these types are documentation, display name, display group, and hidden to name a few. This metadata is extremely helpful for editors, such as UsdView, so users can get a better understanding, or visualization, of the stage. For instance, display name is a very common form of metadata on a UsdPrim to create a nice, human-readable name that will be presented in an editor.
+
+A `UsdVariantSet`, which does not derive from a UsdObject, has no such API to create metadata. If an author would like to produce a `UsdVariantSet` that should be hidden from editors, there isn't a uniform way to do so. Yes, the author could prefix the name of the `UsdVariantSet` with something like "test" or "__", but every editor would need to respect this prefix. A better way to support such a feature on `UsdVariantSet` would be to expose a hidden metadata field. This would be consistent with the UsdObject API and lends itself to other metadata fields that would be applicable for a `UsdVariantSet` like display name.
+
+## Metadata Fields
+
+The following are metadata fields that will be commonly used on a `UsdVariantSet` and will have an explicit API. The fields proposed here will provide the normal accessors and mutators that will be available on a `UsdVariantSet`:
+
+- `documentation` - Information that can describe the role of the `UsdVariantSet` and its intended uses
+- `displayGroup` - Name to assist with grouping similar `UsdVariantSet`s in editors.
+- `displayName` - Name for the `UsdVariantSet` that can be used in editors
+- `hidden` - Boolean field that can inform an editor if the `UsdVariantSet` should be hidden. This field will have a fallback value of `false`
+- `variantDisplayNames` - Mapping of variant name to a variant's display name that can be used in editors
+- `comment` - User notes about a variant set
+- `variantOrder` - User defined ordering of variants, similar to primOrder and propertyOrder
+- `customData` - User defined dictionary of additional metadata
+
+## Custom Metadata Fields
+
+Similar to other types that allow authoring of metadata fields, `UsdVariantSet` will also allow custom metadata fields. These custom fields can be used to author metadata on a `UsdVariantSet` that might be site-specific and do not require explicit API.
+
+## Metadata Value Resolution
+
+As described below, a [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject). But the metadata value resolution process of a `UsdVariantSet` should behave similar to that of UsdObject. For most types the resolution process will be "strongest opinion wins" but other, more complicated types like VtDictionary will be correctly resolved. This will slightly complicate the implementation since `UsdVariantSet` will need to provide this value resolution step, but should provide expected results for authored metadata.
+
+## Example
+
+An example showing metadata on variant sets can be found [here](example.usda)
+
+```
+#usda 1.0
+(
+    defaultPrim = "MilkCartonA"
+)
+
+def Xform "MilkCartonA" (
+    kind = "prop"
+    variants = {
+        string modelingVariant = "Carton_Opened"
+        string shadingComplexity = "full"
+        string shadingTest = "milkBrandA"
+    }
+    add variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
+)
+{
+    variantSet "modelingVariant" (
+        doc = "Modeling variations for the asset"
+    ) = {
+        "ALL_VARIANTS" {
+            float3[] extentsHint = [(-6.27056, -6.53532, 0), (6.14027, 6.10374, 29.8274)]
+
+        }
+        "Carton_Opened" {
+           float3[] extentsHint = [(-6.27056, -6.53532, 0), (6.14027, 6.10374, 29.8274)]
+
+        }
+        "Carton_Sealed" {
+           float3[] extentsHint = [(-6.27056, -6.44992, 0), (6.14027, 6.10374, 29.2792)]
+
+        }
+    }
+    variantSet "shadingComplexity" = {
+        reorder variants = ["none", "display", "modeling", "full"]
+        "display" {
+
+        }
+        "full" {
+
+        }
+        "modeling" {
+
+        }
+        "none" {
+
+        }
+    }
+
+    variantSet "shadingTest" (
+        displayName = "Shading Test Variations"
+        doc = "Shading variations that are currently being explored for product placement"
+        comment = "Added UPC# for the display names"
+        variantDisplayNames = { "milkBrandA" : "Milk Brand A (UPC#: 123-ABC)", "milkBrandB" : "Milk Brand B (UPC#: 456-DEF)" }
+        hidden = True
+    ) = {
+        "milkBrandA" {
+
+        }
+        "milkBrandB" {
+
+        }
+    }
+}
+```
+
+## UsdVariantSet is not a UsdObject
+
+UsdObject is the base class for UsdPrim and UsdProperty that provides the common API for accessing metadata. Investigating metadata support for `UsdVariantSet` immediately raised the question of: *“Should UsdVariantSet be a UsdObject?”*. The answer is no, a `UsdVariantSet` should not be a UsdObject. The reason is more philosophical than technical as a UsdObject is the common base shared amongst types in OpenUSD’s scenegraph. The idea is that a UsdObject is a tangible entity on OpenUSD's scenegraph. These objects can be accessed directly from API such as UsdStage::GetObjectAtPath(), relationships can be established between multiple UsdObjects, they can be included in collections, they will not be discarded during the flattening process, and all UsdObjects share a common set of metadata. This last point is the main reason for asking *"Should UsdVariantSet be a UsdObject?"*; specifically to prevent code duplication. But when thinking about these other points, it becomes clear that deriving `UsdVariantSet` from a UsdObject would require quite a few exemptions in OpenUSD.
+
+From a technical perspective though, deriving `UsdVariantSet` from a UsdObject seems logical. It already provides a lot of the metadata API that is presented in this proposal. But `UsdVariantSet` would also inherit API for metadata such as AssetInfo which is not something that applies to a `UsdVariantSet`. It would also create ambiguity with UsdCollectionAPI and UsdRelationship as those expect SdfPaths to UsdObjects like UsdPrim, UsdAttribute or UsdRelationship. What benefit would a collection containing a `UsdVariantSet` provide? Or what does a relationship from a UsdAttribute to a `UsdVariantSet` mean? The convenience of avoiding code duplication does not warrant changing `UsdVariantSet` to be a UsdObject. There is also precedent in OpenUSD for API that provides metadata support without deriving from UsdObject, UsdStage is one such example.
+
+## Stage Flattening
+
+The stage flattening process will remove all `UsdVariantSet`s when the stage is collapsed into a single merged layer. With all `UsdVariantSet`s being removed, there is no reason to maintain authored metadata as an editor will not have any `UsdVariantSet`s to display. As such, metadata authored for a `UsdVariantSet` will not be preserved when flattened. 

--- a/proposals/variant_set_metadata/README.md
+++ b/proposals/variant_set_metadata/README.md
@@ -12,7 +12,7 @@ Matthew Kuruc
 - [Metadata in OpenUSD](#metadata-in-openusd)
     - [Metadata Fields](#core-metadata-fields)
     - [Custom Metadata Fields](#custom-metadata-fields)
-    - [Metadata Value Resoltuion](#metadata-value-resolution)
+    - [Metadata Value Resolution](#metadata-value-resolution)
 - [Example](#example)
 - [Variant Display Name](#variant-display-names)
 - [Variant Ordering](#variant-ordering)
@@ -108,7 +108,7 @@ def Xform "MilkCartonA" (
         string shadingComplexity = "full"
         string shadingTest = "milkBrandA"
     }
-    add variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
+    prepend variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
 )
 {
     variantSet "modelingVariant" (

--- a/proposals/variant_set_metadata/README.md
+++ b/proposals/variant_set_metadata/README.md
@@ -22,36 +22,73 @@ Matthew Kuruc
 
 ## Introduction
 
-Variants in OpenUSD are a powerful mechanism that allow authors to modify scene description and express opinions for a given prim. These modifications will ultimately contribute to the final result of a prim during composition. Prims, along with attributes and relationships, offer APIs for authoring additional information, referred to as metadata, to assist editors such as usdview. However, there are times when it is desirable to also author metadata about a variant set for similar reasons but there is no facility to do so.
+Variants in OpenUSD are a powerful mechanism that allow authors to modify scene description and 
+express opinions for a given prim. These modifications will ultimately contribute to the final 
+result of a prim during composition. Prims, along with attributes and relationships, 
+offer APIs for authoring additional information, referred to as metadata, to assist editors 
+such as usdview. However, there are times when it is desirable to also author metadata about 
+a variant set for similar reasons but there is no facility to do so.
 
-We propose adding the ability to author metadata on `UsdVariantSet` to support similar functionality available to UsdPrim, UsdAttribute and UsdRelationship. This metadata is intended to be used in editors to display information such as a nicely formatted name for the variant set or whether the variant set should be hidden in certain views. `UsdVariantSet` metadata will not affect the composition behavior for a UsdPrim, UsdAttribute or UsdRelationship on a UsdStage. 
+We propose adding the ability to author metadata on `UsdVariantSet` to support similar 
+functionality available to UsdPrim, UsdAttribute and UsdRelationship. 
+This metadata is intended to be used in editors to display information such as a 
+nicely formatted name for the variant set or whether the variant set should be hidden in certain views.
+`UsdVariantSet` metadata will not affect the composition behavior for a `UsdPrim`, 
+`UsdAttribute` or `UsdRelationship` on a `UsdStage`. 
 
 ## Metadata in OpenUSD
 
-Metadata is a core feature of OpenUSD that is available to `SdfLayer`, `UsdStage`, `UsdPrim` and both subclasses of `UsdProperty`. `UsdPrim` and `UsdProperty` both derive from `UsdObject` which provides API for authoring and accessing metadata. Common examples of metadata available for these types are documentation, display name, display group, and hidden to name a few. This metadata is extremely helpful for editors, such as UsdView, so users can get a better understanding, or visualization, of the stage. For instance, display name is a very common form of metadata on a `UsdPrim` to create a nice, human-readable name that will be presented in an editor.
+Metadata is a core feature of OpenUSD that is available to `SdfLayer`, `UsdStage`, `UsdPrim` 
+and both subclasses of `UsdProperty`. `UsdPrim` and `UsdProperty` both derive from `UsdObject` 
+which provides API for authoring and accessing metadata. 
+Common examples of metadata available for these types are documentation, display name, 
+display group, and hidden to name a few. This metadata is extremely helpful for editors, 
+such as UsdView, so users can get a better understanding, or visualization, of the stage.
+For instance, display name is a very common form of metadata on a `UsdPrim` to create a nice,
+human-readable name that will be presented in an editor.
 
-A `UsdVariantSet`, which does not derive from a `UsdObject`, has no such API to create metadata. If an author would like to produce a `UsdVariantSet` that should be hidden from editors, there isn't a uniform way to do so. Yes, the author could prefix the name of the `UsdVariantSet` with something like "test" or "__", but every editor would need to respect this prefix. A better way to support such a feature on `UsdVariantSet` would be to expose a hidden metadata field. This would be consistent with the `UsdObject` API and lends itself to other metadata fields that would be applicable for a `UsdVariantSet` like display name.
+A `UsdVariantSet`, which does not derive from a `UsdObject`, has no such API to create metadata.
+If an author would like to produce a `UsdVariantSet` that should be hidden from editors,
+there isn't a uniform way to do so. Yes, the author could prefix the name of the `UsdVariantSet` 
+with something like "test" or "__", but every editor would need to respect this prefix.
+A better way to support such a feature on `UsdVariantSet` would be to expose a hidden metadata field.
+This would be consistent with the `UsdObject` API and lends itself to other metadata fields
+that would be applicable for a `UsdVariantSet` like display name.
 
 ## Metadata Fields
 
-The following are metadata fields that will be commonly used on a `UsdVariantSet` and will have an explicit API. The fields proposed here will provide the normal accessors and mutators that will be available on a `UsdVariantSet`:
+The following are metadata fields that will be commonly used on a `UsdVariantSet` 
+and will have an explicit API. The fields proposed here will provide the normal accessors 
+and mutators that will be available on a `UsdVariantSet`:
 
 - `comment` - User notes about a variant set
 - `documentation` - Information that can describe the role of the `UsdVariantSet` and its intended uses
 - `displayGroup` - Name to assist with grouping similar `UsdVariantSet`s in editors.
 - `displayName` - Name for the `UsdVariantSet` that can be used in editors
-- `hidden` - Boolean field that can inform an editor if the `UsdVariantSet` should be hidden. This field will have a fallback value of `false`
-- `variantDisplayNames` - Mapping of variant name to a variant's display name that can be used in editors. See [Variant Display Names](#variant-display-names) for more implementation details.
-- `variantOrder` - User defined ordering of variants, similar to primOrder and propertyOrder. See [Variant Ordering](#variant-ordering) for more implementation details.
+- `hidden` - Boolean field that can inform an editor if the `UsdVariantSet` should be hidden. 
+    This field will have a fallback value of `false`
+- `variantDisplayNames` - Mapping of variant name to a variant's display name that can be used in editors. 
+    See [Variant Display Names](#variant-display-names) for more implementation details.
+- `variantOrder` - User defined ordering of variants, similar to primOrder and propertyOrder. 
+    See [Variant Ordering](#variant-ordering) for more implementation details.
 - `customData` - User defined dictionary of additional metadata
 
 ## Custom Metadata Fields
 
-Similar to other types that allow authoring of metadata fields, `UsdVariantSet` will also allow custom metadata fields that are defined in plugins. These custom fields can be used to author metadata on a `UsdVariantSet` that might be site-specific but should always be applied to the `UsdVariantSet` type.
+Similar to other types that allow authoring of metadata fields, `UsdVariantSet` will also 
+allow custom metadata fields that are defined in plugins. These custom fields can be used to 
+author metadata on a `UsdVariantSet` that might be site-specific but should always be applied 
+to the `UsdVariantSet` type.
 
 ## Metadata Value Resolution
 
-As described below, a [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject). But the metadata value resolution process of a `UsdVariantSet` should behave similar to that of `UsdObject`. For most types the resolution process will be "strongest opinion wins" but other, more complicated types like VtDictionary will be correctly resolved. This will slightly complicate the implementation since `UsdVariantSet` will need to provide this value resolution step, but should provide expected results for authored metadata.
+As described below, a [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject). 
+But the metadata value resolution process of a `UsdVariantSet` should behave 
+similar to that of `UsdObject`. For most types the resolution process will be 
+"strongest opinion wins" but other, more complicated types like VtDictionary will be 
+correctly resolved. This will slightly complicate the implementation since 
+`UsdVariantSet` will need to provide this value resolution step, 
+but should provide expected results for authored metadata.
 
 ## Example
 
@@ -124,27 +161,86 @@ def Xform "MilkCartonA" (
 
 ## Variant Display Names
 
-Adding display names to variants is another metadata field that this proposal would like to support. This field will need to be handled differently than other displayName metadata fields found on types like `UsdPrim` and `UsdProperty`. Specifically, a mapping of variant name to display name will be required as display name can not be added to a variant. First, there is no `UsdVariant` type to add display name API to. Secondly, and most importantly, all fields within a variant are applied directly to a `UsdPrim` when selected. If a displayName metadata field was added to a variant, that field would be applied to the `UsdPrim`'s displayName and not the variant's. It's for this reason that a mapping of variant name to display name will be added to a `UsdVariantSet`. As described in [Metadata Value Resolution](#metadata-value-resolution), the mapping of variant name to display name will need to be correctly resolved and merged.
+Adding display names to variants is another metadata field that this proposal would like to support.
+This field will need to be handled differently than other displayName metadata fields 
+found on types like `UsdPrim` and `UsdProperty`. Specifically, a mapping of variant name
+to display name will be required as display name can not be added to a variant.
+First, there is no `UsdVariant` type to add display name API to. Secondly, and most importantly,
+all fields within a variant are applied directly to a `UsdPrim` when selected.
+If a displayName metadata field was added to a variant, that field would be applied to the
+`UsdPrim`'s displayName and not the variant's. It's for this reason that a mapping of 
+variant name to display name will be added to a `UsdVariantSet`.
+As described in [Metadata Value Resolution](#metadata-value-resolution), 
+the mapping of variant name to display name will need to be correctly resolved and merged.
 
 ## Variant Ordering
 
-One of the metadata fields presented in this proposal is the addition of [variantOrder](#metadata-fields). The goal of this field is simple; to specify an explicit order for how an editor should display variants in a `UsdVariantSet`. When considering the implementation of this metadata field for the `SdfTextFileFormat` it seems consistent with other `SdfSpec`s to use a `reorder variants` statment. This can be seen in the [proposed example](example.usda) but worth calling out specifically as it brings up two questions:
+One of the metadata fields presented in this proposal is the 
+addition of [variantOrder](#metadata-fields). The goal of this field is simple;
+to specify an explicit order for how an editor should display variants in a `UsdVariantSet`.
+When considering the implementation of this metadata field for the `SdfTextFileFormat`
+it seems consistent with other `SdfSpec`s to use a `reorder variants` statment.
+This can be seen in the [proposed example](example.usda) but worth 
+calling out specifically as it brings up two questions:
 
-1. Is a `reorder variants` statement the correct approach for implementing `variantOrder` metadata field?
-2. If so, should the addition of a new `reorder` statement in the `SdfTextFileFormat` require a version bump as it requires changes to the parser?
+1. Is a `reorder variants` statement the correct approach for implementing `variantOrder` 
+    metadata field?
+2. If so, should the addition of a new `reorder` statement in the `SdfTextFileFormat` 
+    require a version bump as it requires changes to the parser?
 
 ## Crate File Format Support
 
-The general consensus is that the USD Crate File Format should "just work" when metadata support is added to `UsdVariantSet`. The proposal does not mention any implementation details regarding the USD Crate File Format as the expectation is that no changes should be necessary. Unfortunately, it is not easy to test out if this assumption is correct due to Crate being a binary file format. This will require further experimentation once the changes proposed here move to the implementation step.
+The general consensus is that the USD Crate File Format should "just work" when 
+metadata support is added to `UsdVariantSet`. The proposal does not mention 
+any implementation details regarding the USD Crate File Format as the expectation 
+is that no changes should be necessary. Unfortunately, it is not easy to test out 
+if this assumption is correct due to Crate being a binary file format.
+This will require further experimentation once the changes proposed here move 
+to the implementation step.
 
 ## UsdVariantSet is not a UsdObject
 
-`UsdObject` is the base class for `UsdPrim` and `UsdProperty` that provides the common API for accessing metadata. Investigating metadata support for `UsdVariantSet` immediately raised the question of: *“Should UsdVariantSet be a UsdObject?”*. The answer is no, a `UsdVariantSet` should not be a UsdObject. The reason is more philosophical than technical as a `UsdObject` is the common base shared amongst types in OpenUSD’s scenegraph. The idea is that a `UsdObject` is a tangible entity on OpenUSD's scenegraph. These objects can be accessed directly from API such as UsdStage::GetObjectAtPath(), relationships can be established between multiple `UsdObject`s, they can be included in collections, they will not be discarded during the flattening process, and all `UsdObject`s share a common set of metadata. This last point is the main reason for asking *"Should UsdVariantSet be a UsdObject?"*; specifically to prevent code duplication. But when thinking about these other points, it becomes clear that deriving `UsdVariantSet` from a `UsdObject` would require quite a few exemptions in OpenUSD.
+`UsdObject` is the base class for `UsdPrim` and `UsdProperty` that provides the 
+common API for accessing metadata. Investigating metadata support for `UsdVariantSet` 
+immediately raised the question of: *“Should UsdVariantSet be a UsdObject?”*. 
+The answer is no, a `UsdVariantSet` should not be a UsdObject. The reason is more 
+philosophical than technical as a `UsdObject` is the common base shared amongst types 
+in OpenUSD’s scenegraph. The idea is that a `UsdObject` is a tangible entity 
+on OpenUSD's scenegraph. These objects can be accessed directly from API such as 
+UsdStage::GetObjectAtPath(), relationships can be established between multiple 
+`UsdObject`s, they can be included in collections, they will not be discarded during 
+the flattening process, and all `UsdObject`s share a common set of metadata. 
+This last point is the main reason for asking *"Should UsdVariantSet be a UsdObject?"*; 
+specifically to prevent code duplication. But when thinking about these other points, 
+it becomes clear that deriving `UsdVariantSet` from a `UsdObject` would require 
+quite a few exemptions in OpenUSD.
 
-From a technical perspective though, deriving `UsdVariantSet` from a `UsdObject` seems logical. It already provides a lot of the metadata API that is presented in this proposal. But `UsdVariantSet` would also inherit API for metadata such as AssetInfo which is not something that applies to a `UsdVariantSet`. It would also create ambiguity with `UsdCollectionAPI` and `UsdRelationship` as those expect `SdfPath`s to `UsdObject`s like `UsdPrim`, `UsdAttribute` or `UsdRelationship`. What benefit would a collection containing a `UsdVariantSet` provide? Or what does a relationship from a `UsdAttribute` to a `UsdVariantSet` mean? The convenience of avoiding code duplication does not warrant changing `UsdVariantSet` to be a `UsdObject`. There is also precedent in OpenUSD for API that provides metadata support without deriving from `UsdObject`, `UsdStage` is one such example.
+From a technical perspective though, deriving `UsdVariantSet` from a `UsdObject` seems logical. 
+It already provides a lot of the metadata API that is presented in this proposal. 
+But `UsdVariantSet` would also inherit API for metadata such as AssetInfo which 
+is not something that applies to a `UsdVariantSet`. It would also create ambiguity 
+with `UsdCollectionAPI` and `UsdRelationship` as those expect `SdfPath`s 
+to `UsdObject`s like `UsdPrim`, `UsdAttribute` or `UsdRelationship`. 
+What benefit would a collection containing a `UsdVariantSet` provide? 
+Or what does a relationship from a `UsdAttribute` to a `UsdVariantSet` mean? 
+The convenience of avoiding code duplication does not warrant changing `UsdVariantSet` 
+to be a `UsdObject`. There is also precedent in OpenUSD for API that provides 
+metadata support without deriving from `UsdObject`, `UsdStage` is one such example.
 
-But answering this question leads to discussion on how to best implement metadata support for `UsdVariantSet`. Since `UsdVariantSet` should not be a `UsdObject` a potential implementation for metadata support could lead to unnecessary code duplication. A better approach might be to refactor common metadata API found in `UsdObject` to private internal utilities that can be used for types that do not derive from `UsdObject`. Types such as `UsdStage` and `UsdVariantSet` could use these utilities to implement their own API for metadata, avoiding code duplication and not deriving from `UsdObject`.
+But answering this question leads to discussion on how to best implement metadata support 
+for `UsdVariantSet`. Since `UsdVariantSet` should not be a `UsdObject` a potential 
+implementation for metadata support could lead to unnecessary code duplication. 
+A better approach might be to refactor common metadata API found in `UsdObject` to 
+private internal utilities that can be used for types that do not derive from 
+`UsdObject`. Types such as `UsdStage` and `UsdVariantSet` could use these utilities 
+to implement their own API for metadata, avoiding code duplication and 
+not deriving from `UsdObject`.
 
 ## Stage Flattening
 
-The stage flattening process will remove all `UsdVariantSet`s when the stage is collapsed into a single merged layer. With all `UsdVariantSet`s being removed, there is no reason to maintain authored metadata as an editor will not have any `UsdVariantSet`s to display. As such, metadata authored for a `UsdVariantSet` will not be preserved when flattened. This could be viewed as another argument for [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject) since they are discarded during the flattening process.
+The stage flattening process will remove all `UsdVariantSet`s when the stage is collapsed 
+into a single merged layer. With all `UsdVariantSet`s being removed, there is no reason 
+to maintain authored metadata as an editor will not have any `UsdVariantSet`s to display. 
+As such, metadata authored for a `UsdVariantSet` will not be preserved when flattened. 
+This could be viewed as another argument for [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject) 
+since they are discarded during the flattening process.

--- a/proposals/variant_set_metadata/README.md
+++ b/proposals/variant_set_metadata/README.md
@@ -30,7 +30,7 @@ such as usdview. However, there are times when it is desirable to also author me
 a variant set for similar reasons but there is no facility to do so.
 
 We propose adding the ability to author metadata on `UsdVariantSet` to support similar 
-functionality available to UsdPrim, UsdAttribute and UsdRelationship. 
+functionality available to `UsdPrim`, `UsdAttribute` and `UsdRelationship`. 
 This metadata is intended to be used in editors to display information such as a 
 nicely formatted name for the variant set or whether the variant set should be hidden in certain views.
 `UsdVariantSet` metadata will not affect the composition behavior for a `UsdPrim`, 
@@ -179,7 +179,7 @@ One of the metadata fields presented in this proposal is the
 addition of [variantOrder](#metadata-fields). The goal of this field is simple;
 to specify an explicit order for how an editor should display variants in a `UsdVariantSet`.
 When considering the implementation of this metadata field for the `SdfTextFileFormat`
-it seems consistent with other `SdfSpec`s to use a `reorder variants` statment.
+it seems consistent with other `SdfSpec`s to use a `reorder variants` statement.
 This can be seen in the [proposed example](example.usda) but worth 
 calling out specifically as it brings up two questions:
 

--- a/proposals/variant_set_metadata/README.md
+++ b/proposals/variant_set_metadata/README.md
@@ -2,19 +2,21 @@
 
 Copyright &copy; 2024, NVIDIA Corporation, version 1.0
 
-Joshua Miller   
 Tyler Hubbard   
+Joshua Miller   
 Matthew Kuruc   
 
 ## Contents
 
 - [Introduction](#introduction)
 - [Metadata in OpenUSD](#metadata-in-openusd)
-- [Metadata Fields](#core-metadata-fields)
-- [Custom Metadata Fields](#custom-metadata-fields)
-- [Metadata Value Resoltuion](#metadata-value-resolution)
+    - [Metadata Fields](#core-metadata-fields)
+    - [Custom Metadata Fields](#custom-metadata-fields)
+    - [Metadata Value Resoltuion](#metadata-value-resolution)
 - [Example](#example)
-- [UsdVariantSet is not a UsdObject](#`UsdVariantSet`-is-not-a-usdobject)
+- [Variant Ordering](#variant-ordering)
+- [Crate File Format Support](#crate-file-format-support)
+- [UsdVariantSet is not a UsdObject](#UsdVariantSet-is-not-a-usdobject)
 - [Stage Flattening](#stage-flattening)
 
 ## Introduction
@@ -25,9 +27,9 @@ We propose adding the ability to author metadata on `UsdVariantSet` to support s
 
 ## Metadata in OpenUSD
 
-Metadata is a core feature of OpenUSD that is available to SdfLayer, UsdStage, UsdPrim and both subclasses of UsdProperty. UsdPrim and UsdProperty both derive from UsdObject which provides API for authoring and accessing metadata. Common examples of metadata available for these types are documentation, display name, display group, and hidden to name a few. This metadata is extremely helpful for editors, such as UsdView, so users can get a better understanding, or visualization, of the stage. For instance, display name is a very common form of metadata on a UsdPrim to create a nice, human-readable name that will be presented in an editor.
+Metadata is a core feature of OpenUSD that is available to `SdfLayer`, `UsdStage`, `UsdPrim` and both subclasses of `UsdProperty`. `UsdPrim` and `UsdProperty` both derive from `UsdObject` which provides API for authoring and accessing metadata. Common examples of metadata available for these types are documentation, display name, display group, and hidden to name a few. This metadata is extremely helpful for editors, such as UsdView, so users can get a better understanding, or visualization, of the stage. For instance, display name is a very common form of metadata on a `UsdPrim` to create a nice, human-readable name that will be presented in an editor.
 
-A `UsdVariantSet`, which does not derive from a UsdObject, has no such API to create metadata. If an author would like to produce a `UsdVariantSet` that should be hidden from editors, there isn't a uniform way to do so. Yes, the author could prefix the name of the `UsdVariantSet` with something like "test" or "__", but every editor would need to respect this prefix. A better way to support such a feature on `UsdVariantSet` would be to expose a hidden metadata field. This would be consistent with the UsdObject API and lends itself to other metadata fields that would be applicable for a `UsdVariantSet` like display name.
+A `UsdVariantSet`, which does not derive from a `UsdObject`, has no such API to create metadata. If an author would like to produce a `UsdVariantSet` that should be hidden from editors, there isn't a uniform way to do so. Yes, the author could prefix the name of the `UsdVariantSet` with something like "test" or "__", but every editor would need to respect this prefix. A better way to support such a feature on `UsdVariantSet` would be to expose a hidden metadata field. This would be consistent with the `UsdObject` API and lends itself to other metadata fields that would be applicable for a `UsdVariantSet` like display name.
 
 ## Metadata Fields
 
@@ -44,11 +46,11 @@ The following are metadata fields that will be commonly used on a `UsdVariantSet
 
 ## Custom Metadata Fields
 
-Similar to other types that allow authoring of metadata fields, `UsdVariantSet` will also allow custom metadata fields. These custom fields can be used to author metadata on a `UsdVariantSet` that might be site-specific and do not require explicit API.
+Similar to other types that allow authoring of metadata fields, `UsdVariantSet` will also allow custom metadata fields that are defined in plugins. These custom fields can be used to author metadata on a `UsdVariantSet` that might be site-specific but should always be applied to the `UsdVariantSet` type.
 
 ## Metadata Value Resolution
 
-As described below, a [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject). But the metadata value resolution process of a `UsdVariantSet` should behave similar to that of UsdObject. For most types the resolution process will be "strongest opinion wins" but other, more complicated types like VtDictionary will be correctly resolved. This will slightly complicate the implementation since `UsdVariantSet` will need to provide this value resolution step, but should provide expected results for authored metadata.
+As described below, a [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject). But the metadata value resolution process of a `UsdVariantSet` should behave similar to that of `UsdObject`. For most types the resolution process will be "strongest opinion wins" but other, more complicated types like VtDictionary will be correctly resolved. This will slightly complicate the implementation since `UsdVariantSet` will need to provide this value resolution step, but should provide expected results for authored metadata.
 
 ## Example
 
@@ -119,12 +121,23 @@ def Xform "MilkCartonA" (
 }
 ```
 
+## Variant Ordering
+
+One of the metadata fields presented in this proposal is the addition of [variantOrder](#metadata-fields). The goal of this field is simple; to specify an explicit order for how an editor should display variants in a `UsdVariantSet`. When considering the implementation of this metadata field for the `SdfTextFileFormat` it seems consistent with other `SdfSpec`s to use a `reorder variants` statment. This can be seen in the [proposed example](example.usda) but worth calling out specifically as it brings up two questions:
+
+1. Is a `reorder variants` statement the correct approach for implementing `variantOrder` metadata field?
+2. If so, should the addition of a new `reorder` statement in the `SdfTextFileFormat` require a version bump as it requires changes to the parser?
+
+## Crate File Format Support
+
+The general consensus is that the USD Crate File Format should "just work" when metadata support is added to `UsdVariantSet`. The proposal does not mention any implementation details regarding the USD Crate File Format as the expectation is that no changes should be necessary. Unfortunately, it is not easy to test out if this assumption is correct due to Crate being a binary file format. This will require further experimentation once the changes proposed here move to the implementation step.
+
 ## UsdVariantSet is not a UsdObject
 
-UsdObject is the base class for UsdPrim and UsdProperty that provides the common API for accessing metadata. Investigating metadata support for `UsdVariantSet` immediately raised the question of: *“Should UsdVariantSet be a UsdObject?”*. The answer is no, a `UsdVariantSet` should not be a UsdObject. The reason is more philosophical than technical as a UsdObject is the common base shared amongst types in OpenUSD’s scenegraph. The idea is that a UsdObject is a tangible entity on OpenUSD's scenegraph. These objects can be accessed directly from API such as UsdStage::GetObjectAtPath(), relationships can be established between multiple UsdObjects, they can be included in collections, they will not be discarded during the flattening process, and all UsdObjects share a common set of metadata. This last point is the main reason for asking *"Should UsdVariantSet be a UsdObject?"*; specifically to prevent code duplication. But when thinking about these other points, it becomes clear that deriving `UsdVariantSet` from a UsdObject would require quite a few exemptions in OpenUSD.
+UsdObject is the base class for `UsdPrim` and `UsdPropert` that provides the common API for accessing metadata. Investigating metadata support for `UsdVariantSet` immediately raised the question of: *“Should UsdVariantSet be a UsdObject?”*. The answer is no, a `UsdVariantSet` should not be a UsdObject. The reason is more philosophical than technical as a `UsdObject` is the common base shared amongst types in OpenUSD’s scenegraph. The idea is that a `UsdObject` is a tangible entity on OpenUSD's scenegraph. These objects can be accessed directly from API such as UsdStage::GetObjectAtPath(), relationships can be established between multiple UsdObjects, they can be included in collections, they will not be discarded during the flattening process, and all UsdObjects share a common set of metadata. This last point is the main reason for asking *"Should UsdVariantSet be a UsdObject?"*; specifically to prevent code duplication. But when thinking about these other points, it becomes clear that deriving `UsdVariantSet` from a `UsdObject` would require quite a few exemptions in OpenUSD.
 
-From a technical perspective though, deriving `UsdVariantSet` from a UsdObject seems logical. It already provides a lot of the metadata API that is presented in this proposal. But `UsdVariantSet` would also inherit API for metadata such as AssetInfo which is not something that applies to a `UsdVariantSet`. It would also create ambiguity with UsdCollectionAPI and UsdRelationship as those expect SdfPaths to UsdObjects like UsdPrim, UsdAttribute or UsdRelationship. What benefit would a collection containing a `UsdVariantSet` provide? Or what does a relationship from a UsdAttribute to a `UsdVariantSet` mean? The convenience of avoiding code duplication does not warrant changing `UsdVariantSet` to be a UsdObject. There is also precedent in OpenUSD for API that provides metadata support without deriving from UsdObject, UsdStage is one such example.
+From a technical perspective though, deriving `UsdVariantSet` from a `UsdObject` seems logical. It already provides a lot of the metadata API that is presented in this proposal. But `UsdVariantSet` would also inherit API for metadata such as AssetInfo which is not something that applies to a `UsdVariantSet`. It would also create ambiguity with UsdCollectionAPI and UsdRelationship as those expect SdfPaths to UsdObjects like UsdPrim, UsdAttribute or UsdRelationship. What benefit would a collection containing a `UsdVariantSet` provide? Or what does a relationship from a UsdAttribute to a `UsdVariantSet` mean? The convenience of avoiding code duplication does not warrant changing `UsdVariantSet` to be a UsdObject. There is also precedent in OpenUSD for API that provides metadata support without deriving from UsdObject, UsdStage is one such example.
 
 ## Stage Flattening
 
-The stage flattening process will remove all `UsdVariantSet`s when the stage is collapsed into a single merged layer. With all `UsdVariantSet`s being removed, there is no reason to maintain authored metadata as an editor will not have any `UsdVariantSet`s to display. As such, metadata authored for a `UsdVariantSet` will not be preserved when flattened. 
+The stage flattening process will remove all `UsdVariantSet`s when the stage is collapsed into a single merged layer. With all `UsdVariantSet`s being removed, there is no reason to maintain authored metadata as an editor will not have any `UsdVariantSet`s to display. As such, metadata authored for a `UsdVariantSet` will not be preserved when flattened. This could be viewed as another argument for [UsdVariantSet should not be a UsdObject](#usdvariantset-is-not-a-usdobject) since they are discarded during the flattening process.

--- a/proposals/variant_set_metadata/example.usda
+++ b/proposals/variant_set_metadata/example.usda
@@ -10,7 +10,7 @@ def Xform "MilkCartonA" (
         string shadingComplexity = "full"
         string shadingTest = "milkBrandA"
     }
-    add variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
+    prepend variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
 )
 {
     variantSet "modelingVariant" (

--- a/proposals/variant_set_metadata/example.usda
+++ b/proposals/variant_set_metadata/example.usda
@@ -1,0 +1,62 @@
+#usda 1.0
+(
+    defaultPrim = "MilkCartonA"
+)
+
+def Xform "MilkCartonA" (
+    kind = "prop"
+    variants = {
+        string modelingVariant = "Carton_Opened"
+        string shadingComplexity = "full"
+        string shadingTest = "milkBrandA"
+    }
+    add variantSets = ["modelingVariant", "shadingComplexity", "shadingTest"]
+)
+{
+    variantSet "modelingVariant" (
+        doc = "Modeling variations for the asset"
+    ) = {
+        "ALL_VARIANTS" {
+            float3[] extentsHint = [(-6.27056, -6.53532, 0), (6.14027, 6.10374, 29.8274)]
+
+        }
+        "Carton_Opened" {
+           float3[] extentsHint = [(-6.27056, -6.53532, 0), (6.14027, 6.10374, 29.8274)]
+
+        }
+        "Carton_Sealed" {
+           float3[] extentsHint = [(-6.27056, -6.44992, 0), (6.14027, 6.10374, 29.2792)]
+
+        }
+    }
+    variantSet "shadingComplexity" = {
+        reorder variants = ["none", "display", "modeling", "full"]
+        "display" {
+
+        }
+        "full" {
+
+        }
+        "modeling" {
+
+        }
+        "none" {
+
+        }
+    }
+
+    variantSet "shadingTest" (
+        displayName = "Shading Test Variations"
+        doc = "Shading variations that are currently being explored for product placement"
+        comment = "Added UPC# for the display names"
+        variantDisplayNames = { "milkBrandA" : "Milk Brand A (UPC#: 123-ABC)", "milkBrandB" : "Milk Brand B (UPC#: 456-DEF)" }
+        hidden = True
+    ) = {
+        "milkBrandA" {
+
+        }
+        "milkBrandB" {
+
+        }
+    }
+}

--- a/proposals/variant_set_metadata/example.usda
+++ b/proposals/variant_set_metadata/example.usda
@@ -46,9 +46,9 @@ def Xform "MilkCartonA" (
     }
 
     variantSet "shadingTest" (
+        """Added UPC# for the display names"""
         displayName = "Shading Test Variations"
         doc = "Shading variations that are currently being explored for product placement"
-        comment = "Added UPC# for the display names"
         variantDisplayNames = { "milkBrandA" : "Milk Brand A (UPC#: 123-ABC)", "milkBrandB" : "Milk Brand B (UPC#: 456-DEF)" }
         hidden = True
     ) = {


### PR DESCRIPTION
### Description of Proposal

A proposal for adding metadata support to `UsdVariantSet` in OpenUSD. This proposal is a follow-up from a conversation between @nvmkuruc and @spiffmon  on [AOUSD](https://forum.aousd.org/t/variant-set-metadata/1404).

Broadly speaking, this proposal aims to add common metadata fields to `UsdVariantSet` that are found on `UsdPrim`, `UsdRelationship` and `UsdAttribute` to assist with GUIs and editors when displaying variants.

[Link to Rendered Proposal](https://github.com/NVIDIA-Omniverse/USD-proposals/blob/variant-set-metadata/proposals/variant_set_metadata/README.md)

### Supporting Materials

Open Issues:
* [Variants do not preserve order #3083](https://github.com/PixarAnimationStudios/OpenUSD/issues/3083)

### Contributing

<!--
Please review the  [Contributing](https://graphics.pixar.com/usd/release/contributing_to_usd.html) page in the
documentation for the Supplemental Terms that apply to this repository.
Place an X in the box when you have reviewed and agree to the Supplemental Terms.
-->
- [x] I agree to and accept the [Supplemental Terms](https://graphics.pixar.com/usd/release/contributing_supplemental.html).
