### PR TITLE
Deformable Body Physics in USD

### DIFF
--- a/proposals/physics_deformables/README.md
+++ b/proposals/physics_deformables/README.md
@@ -1,0 +1,59 @@
+# Deformable Body Physics in USD
+
+**Status:** Draft — under active discussion in the [Alliance for OpenUSD (AOUSD)](https://aousd.org) Physics Working Group. Details are expected to evolve as the proposal is reviewed.
+
+## Proposal document
+
+> [!NOTE]
+> **Full proposal:** [wp_deformable_physics.md](./wp_deformable_physics.md)
+> — includes `.usda` examples and illustrative figures.
+
+## Summary
+
+After OpenUSD was extended with the ability to express rigid body physics in 2021, this proposal extends `UsdPhysics` with a basic, interoperable set of abstractions for **deformable body dynamics**, covering the elastic deformation of volumes, surfaces (e.g. cloth, shells), and curves (e.g. hair, rods).
+
+The design goals follow those of the existing rigid body schema:
+
+- A minimal, **backwards-compatible** addition that preserves the ability to load existing assets, including those that mix rigid and deformable content.
+- **Interoperability** with the existing rigid body abstractions, so volume, surface, and curve deformables can be represented and believably simulated.
+- Real-world engineering quantities for material properties, with USD's unit independence preserved.
+- Material properties attached to materials rather than to simulated objects, and a preference for adding APIs to existing classes over introducing new prims.
+
+## What the proposal covers
+
+- Rigid body refactor that factors shared attributes into a `UsdPhysicsBodyAPI` pseudo-base, retaining backwards compatibility.
+- Deformable materials for volumes, surfaces, and curves (Young's modulus, Poisson's ratio, thickness, and stretch/shear/bend/twist stiffness).
+- Deformable bodies, simulation geometry, and rest shape (tetrahedral, triangular, and curve representations).
+- Collision and graphics geometries, and point-based bind poses that support geometry embeddings.
+- Material assignment and mass distribution.
+- Kinematic deformables, attachments, and element collision filtering.
+
+## New schema types
+
+The proposal introduces the following `UsdPhysics` types:
+
+| Type | Description |
+| --- | --- |
+| [`UsdPhysicsBodyAPI`](./wp_deformable_physics.md#rigid-body-refactor) | Pseudo-base body API factored out of the rigid body schema and shared with deformables. |
+| [`UsdPhysicsDeformableBodyAPI`](./wp_deformable_physics.md#deformable-bodies) | Marks a prim and its subtree as a deformable body. |
+| [`UsdPhysicsVolumeDeformableMaterialAPI`](./wp_deformable_physics.md#deformable-materials) | Material properties for volume deformables (Young's modulus, Poisson's ratio). |
+| [`UsdPhysicsSurfaceDeformableMaterialAPI`](./wp_deformable_physics.md#deformable-materials) | Material properties for surface deformables (thickness, stretch/shear/bend stiffness). |
+| [`UsdPhysicsCurvesDeformableMaterialAPI`](./wp_deformable_physics.md#deformable-materials) | Material properties for curve deformables (thickness, stretch/shear/bend/twist stiffness). |
+| [`UsdPhysicsVolumeDeformableSimAPI`](./wp_deformable_physics.md#simulation-geometry-and-rest-shape) | Applied to a `UsdGeomTetMesh` to define a volume deformable's rest shape. |
+| [`UsdPhysicsSurfaceDeformableSimAPI`](./wp_deformable_physics.md#simulation-geometry-and-rest-shape) | Applied to a triangular `UsdGeomMesh` to define a surface deformable's rest shape. |
+| [`UsdPhysicsCurvesDeformableSimAPI`](./wp_deformable_physics.md#simulation-geometry-and-rest-shape) | Applied to a linear `UsdGeomBasisCurves` to define a curve deformable's rest shape. |
+| [`UsdPhysicsDeformablePoseAPI`](./wp_deformable_physics.md#geometry-embeddings) | Multiple-apply API that authors the bind poses used to support geometry embedding. |
+| [`UsdPhysicsAttachment`](./wp_deformable_physics.md#attachments) | Typed prim that attaches deformables to each other, to rigid bodies, or to a static frame. |
+| [`UsdPhysicsElementCollisionFilter`](./wp_deformable_physics.md#element-collision-filtering) | Typed prim providing fine-grained, per-element collision filtering for deformable colliders. |
+
+It also reuses or modifies existing types:
+
+| Type | Change |
+| --- | --- |
+| [`UsdPhysicsRigidBodyAPI`](./wp_deformable_physics.md#rigid-body-refactor) | Refactored to share attributes via `UsdPhysicsBodyAPI`; adds `bodyEnabled`, retaining `rigidBodyEnabled` for backwards compatibility. |
+| [`UsdPhysicsMaterialAPI`](./wp_deformable_physics.md#physics-material) | Reused for deformables, with `restitution` documented as ignored. |
+
+## Notes
+
+- This is a **work in progress**; the proposal is being developed and discussed in the AOUSD Physics Working Group, and the schema is subject to change.
+- The proposal builds on, and is intended to interoperate with, the existing `UsdPhysics` rigid body schema. Prose refers to schema types by their C++ class names (e.g. `UsdPhysicsRigidBodyAPI`), while `.usda` examples use the registered token names (e.g. `PhysicsRigidBodyAPI`).

--- a/proposals/physics_deformables/images/collisionAPI_surf.svg
+++ b/proposals/physics_deformables/images/collisionAPI_surf.svg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1222.8135"
+   height="1037.6399"
+   viewBox="0 0 1222.8135 1037.6399"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g3"
+     style="stroke:#e7c2be;stroke-width:3.77953;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     transform="translate(-80.29769,-51.749634)">
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1282.9825,378.07037 -160.9334,32.02357 53.9235,348.60574 -265.95809,20.74365 -53.69027,292.11427"
+       id="path2-6-7" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 950.87837,126.67018 171.17073,283.42376 -277.03775,97.12045 65.00316,272.22894 -381.64049,40.59231"
+       id="path2-5" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 950.87837,126.67018 -245.65833,146.08121 139.79131,234.463 -351.45856,135.86827 34.82123,176.95298"
+       id="path2-6" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 522.89597,73.359162 705.22004,272.75139 418.63396,456.48398 493.55279,643.08266 100.44182,768.51274"
+       id="path2" />
+  </g>
+  <g
+     id="g2"
+     transform="translate(-80.29769,-51.749634)">
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 523.04367,73.533035 491.71221,270.47368 706.11322,273.14592 738.04788,76.410415 Z"
+       id="path1" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 738.04788,76.410415 -31.93466,196.735505 213.26679,50.7104 31.69674,-197.15035 z"
+       id="path1-8" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 951.07675,126.70597 -31.69674,197.15035 203.06789,86.42882 33.0025,-198.35358 z"
+       id="path1-8-7" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1155.4504,211.93156 -33.0025,198.35358 125.4637,162.01541 35.0156,-194.18786 z"
+       id="path1-8-7-2" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 491.71221,270.47368 -73.07534,185.34457 213.7228,1.5419 73.75355,-184.21423 z"
+       id="path1-1" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 706.11322,273.14592 -73.75355,184.21423 213.0407,49.80613 73.97964,-183.30996 z"
+       id="path1-8-8" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 919.38001,323.85632 -73.97964,183.30996 203.18093,86.42882 73.8666,-183.30996 z"
+       id="path1-8-7-1" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1122.4479,410.28514 -73.8666,183.30996 126.9163,165.25555 72.414,-186.5501 z"
+       id="path1-8-7-2-9" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 418.63687,455.81825 282.55292,640.69647 493.43709,644.00812 632.35967,457.36015 Z"
+       id="path1-2" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 632.35967,457.36015 493.43709,644.00812 707.90495,693.70226 845.40037,507.16628 Z"
+       id="path1-8-5" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 845.40037,507.16628 707.90495,693.70226 910.37245,779.49062 1048.5813,593.5951 Z"
+       id="path1-8-7-8" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1048.5813,593.5951 910.37245,779.49062 1037.0599,944.27475 1175.4976,758.85065 Z"
+       id="path1-8-7-2-6" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 282.55292,640.69647 -180.4325,127.24663 213.28205,1.71312 178.03462,-125.6481 z"
+       id="path1-1-7" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 493.43709,644.00812 315.40247,769.65622 528.18971,820.04691 707.90495,693.70226 Z"
+       id="path1-8-8-7" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 707.90495,693.70226 528.18971,820.04691 730.20749,906.64028 910.37245,779.49062 Z"
+       id="path1-8-7-1-2" />
+    <path
+       style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 910.37245,779.49062 730.20749,906.64028 856.31813,1071.8881 1037.0599,944.27475 Z"
+       id="path1-8-7-2-9-2" />
+  </g>
+  <g
+     id="g4"
+     transform="translate(-80.29769,-51.749634)">
+    <ellipse
+       style="opacity:1;fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3"
+       cx="523.11407"
+       cy="73.813049"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9"
+       cx="738.40356"
+       cy="76.304222"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6"
+       cx="951.0423"
+       cy="126.87489"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4"
+       cx="1155.4127"
+       cy="213.55547"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-8"
+       cx="615.0177"
+       cy="174.54688"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-7"
+       cx="829.41125"
+       cy="199.4359"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-5"
+       cx="1039.3622"
+       cy="273.30035"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-8"
+       cx="1207.8961"
+       cy="393.12973"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-8-4"
+       cx="562.20013"
+       cy="364.52811"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-7-4"
+       cx="775.61829"
+       cy="390.13409"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-5-4"
+       cx="983.06042"
+       cy="459.48056"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-8-4"
+       cx="1147.1598"
+       cy="578.04291"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-8-4-0"
+       cx="454.62653"
+       cy="548.56659"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-7-4-7"
+       cx="671.8457"
+       cy="574.80609"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-5-4-7"
+       cx="877.38733"
+       cy="640.98499"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-8-4-8"
+       cx="1047.5051"
+       cy="768.73322"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-8-4-0-8"
+       cx="298.34161"
+       cy="705.71869"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-7-4-7-2"
+       cx="510.33435"
+       cy="730.69116"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-5-4-7-5"
+       cx="719.677"
+       cy="799.72083"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-8-4-8-2"
+       cx="885.04352"
+       cy="919.39185"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-6"
+       cx="1281.0477"
+       cy="378.65353"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-3"
+       cx="493.04745"
+       cy="269.96274"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-2"
+       cx="706.12952"
+       cy="273.3147"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-8"
+       cx="918.88019"
+       cy="325.00522"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-2"
+       cx="1121.6523"
+       cy="411.16101"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-6-5"
+       cx="1247.2058"
+       cy="571.04523"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-3-6"
+       cx="419.57474"
+       cy="455.7645"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-2-2"
+       cx="632.01343"
+       cy="457.93893"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-8-1"
+       cx="844.96887"
+       cy="507.55933"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-2-4"
+       cx="1047.2805"
+       cy="594.23993"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-6-5-6"
+       cx="1175.2911"
+       cy="756.01202"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-3-6-0"
+       cx="283.84479"
+       cy="639.98804"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-2-2-3"
+       cx="494.14963"
+       cy="644.45654"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-8-1-6"
+       cx="706.78827"
+       cy="693.76025"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-2-4-4"
+       cx="909.41669"
+       cy="779.80725"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-6-5-6-9"
+       cx="1036.1603"
+       cy="944.43018"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-3-6-0-4"
+       cx="102.36111"
+       cy="767.39532"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-2-2-3-0"
+       cx="317.65054"
+       cy="768.61945"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-8-1-6-5"
+       cx="529.6557"
+       cy="818.55664"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-2-4-4-9"
+       cx="730.38361"
+       cy="907.1377"
+       rx="19.795702"
+       ry="19.7957" />
+    <ellipse
+       style="fill:#1f7239;fill-opacity:0.264535;stroke:#1f7239;stroke-width:4.53543;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       id="path3-9-6-4-6-5-6-9-6"
+       cx="857.76074"
+       cy="1067.3262"
+       rx="19.795702"
+       ry="19.7957" />
+  </g>
+</svg>

--- a/proposals/physics_deformables/images/collisionAPI_volA.svg
+++ b/proposals/physics_deformables/images/collisionAPI_volA.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1054.3516"
+   height="972.65845"
+   viewBox="0 0 1054.3516 972.65845"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g2"
+     transform="translate(-27.174602,-42.929044)">
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 278.81299,116.22131 455.08781,281.33529 431.21501,46.075028"
+       id="path2" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 631.70875,103.46127 455.08781,281.33529 716.17964,280.08005"
+       id="path2-9" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 243.16788,482.16718 195.32074,247.06639 30.65109,375.70301"
+       id="path2-9-3" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 243.16788,482.16718 455.08781,281.33529 194.99409,247.37051"
+       id="path2-9-3-2" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 654.52296,446.53307 455.08781,281.33529 466.24502,448.98088"
+       id="path2-9-3-2-2" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 654.52296,446.53307 -188.27794,2.44781 -223.07714,33.1863"
+       id="path2-9-3-2-2-0" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 243.16788,482.16718 430.1714,712.33648 123.91315,647.40774"
+       id="path2-9-3-2-2-0-0" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 654.52296,446.53307 430.1714,712.33648 466.24502,448.98088"
+       id="path2-9-3-2-2-0-0-0" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 819.07356,493.82273 763.24823,755.36479 654.52296,446.53307"
+       id="path2-9-3-2-2-0-0-0-0" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1069.665,730.3819 762.06682,754.92176 1078.9294,400.21814"
+       id="path2-9-3-2-2-0-0-0-0-5" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 833.64227,1013.9887 763.24823,755.36479 997.37619,920.25485"
+       id="path2-9-3-2-2-0-0-0-0-5-1" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="M 833.10375,1013.0611 430.1714,712.33648 763.24823,755.36479"
+       id="path2-9-3-2-2-0-0-0-0-5-1-4" />
+    <path
+       style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 148.948,871.86953 430.1714,712.33648 301.75387,1013.6795"
+       id="path2-9-3-2-2-0-0-0-0-5-1-4-0" />
+  </g>
+  <path
+     style="fill:none;stroke:#af3429;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.8999453,239.33807 167.50633,204.03292 251.38651,72.896306 403.78852,2.0116459 604.62839,59.900786 688.50857,237.11243 627.0752,403.69138 l 165.39754,47.25644 259.91036,-94.51288 -9.4513,330.79507 -72.06601,189.02576 -165.39753,94.51289 H 273.83332 L 121.4313,828.99933 96.621668,604.53124 215.94418,439.13371 2.5264833,333.71377 Z"
+     id="path1" />
+</svg>

--- a/proposals/physics_deformables/images/collisionAPI_volB.svg
+++ b/proposals/physics_deformables/images/collisionAPI_volB.svg
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1156.5017"
+   height="991.71863"
+   viewBox="0 0 1156.5017 991.71863"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g3"
+     transform="translate(-16.245336,-24.175394)"
+     style="opacity:0.577">
+    <g
+       id="g2"
+       transform="translate(-0.87765958)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5"
+       transform="translate(163.78924,164.67064)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7"
+       transform="matrix(-1,0,0,1,695.86342,8.3463438e-4)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0"
+       transform="matrix(-1,0,0,1,531.19679,164.64937)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-1"
+       transform="translate(328.4604,0.00213259)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-1"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-7"
+       transform="translate(493.1273,164.67278)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-3" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-0"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-04"
+       transform="matrix(-1,0,0,1,1025.2015,0.00296759)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-8" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-3"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-0"
+       transform="matrix(-1,0,0,1,860.53485,164.65151)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-2"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-1-35"
+       transform="translate(657.80109,329.31624)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-1-6" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-1-6"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-7-6"
+       transform="translate(822.46799,493.98688)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-3-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-0-6"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-04-7"
+       transform="matrix(-1,0,0,1,1354.5422,329.31707)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-8-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-3-1"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-0-9"
+       transform="matrix(-1,0,0,1,1189.8755,493.96561)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-1-16" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-2-2"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-8"
+       transform="translate(-0.85342766,329.30533)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-57" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-7"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-0"
+       transform="translate(163.81348,493.97597)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-8" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-9"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-3"
+       transform="matrix(-1,0,0,1,695.88766,329.30616)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-0" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-7"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-4"
+       transform="matrix(-1,0,0,1,531.22103,493.9547)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-8"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-1-3"
+       transform="translate(328.48464,329.30746)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-1-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-1-1"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-7-0"
+       transform="translate(493.15154,493.97811)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-3-0" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-0-8"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-04-3"
+       transform="matrix(-1,0,0,1,1025.2257,329.3083)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-8-4" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-3-5"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-0-0"
+       transform="matrix(-1,0,0,1,860.55913,493.95684)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-1-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-2-4"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-1-35-5"
+       transform="translate(657.81336,658.61163)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-1-6-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-1-6-3"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-04-7-9"
+       transform="matrix(-1,0,0,1,1354.5546,658.61246)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-8-7-2" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-3-1-6"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-0-9-5"
+       transform="matrix(-1,0,0,1,1189.8879,823.261)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-1-16-3" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-2-2-2"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-8-4"
+       transform="translate(-0.84115466,658.60072)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-57-4" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-7-4"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-0-2"
+       transform="translate(163.82575,823.27136)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-8-7" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-9-9"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-3-2"
+       transform="matrix(-1,0,0,1,695.89993,658.60155)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-0-3" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-7-7"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-4-3"
+       transform="matrix(-1,0,0,1,531.2333,823.25009)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-7-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-8-5"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-1-3-7"
+       transform="translate(328.49691,658.60285)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-1-7-8" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-1-1-5"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-5-7-0-8"
+       transform="translate(493.16381,823.2735)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-5-3-0-3" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-40-0-8-2"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-04-3-4"
+       transform="matrix(-1,0,0,1,1025.2381,658.60369)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-8-4-1" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-3-5-1"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-7-0-0-0-5"
+       transform="matrix(-1,0,0,1,860.5714,823.25223)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-7-2-1-1-9" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-45-2-2-4-5"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+    <g
+       id="g2-3"
+       transform="translate(-165.56221,164.68498)">
+      <path
+         style="fill:none;stroke:#e7c2be;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 183.69732,25.806576 347.94919,190.31704"
+         id="path2-8" />
+      <rect
+         style="fill:none;fill-opacity:0.264535;stroke:#af3429;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect1-4"
+         width="164.6656"
+         height="164.6656"
+         x="183.69731"
+         y="26.065159" />
+    </g>
+  </g>
+  <path
+     style="fill:none;stroke:#1f7239;stroke-width:5.29134;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+     d="M 99.60573,219.22886 213.11637,230.93099 285.66956,191.14375 358.22275,49.548011 471.73339,12.101203 602.79722,29.654394 711.627,158.3778 l -8.19149,136.91489 -57.34042,101.80851 278.51064,49.14894 177.87237,-95.95745 -15.2128,183.7234 -40.9574,186.06383 -79.57451,126.38298 -126.38298,77.23405 -457.55319,-5.85107 -138.08511,-86.59574 -46.80851,-128.72341 10.53191,-153.29787 92.44681,-108.82979 58.51064,-37.44681 -38.61702,-38.61702 -110,-14.04255 -84.25532,-69.04255 z"
+     id="path3" />
+</svg>

--- a/proposals/physics_deformables/images/defaul_dihedral_rest_angle2.svg
+++ b/proposals/physics_deformables/images/defaul_dihedral_rest_angle2.svg
@@ -1,0 +1,813 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1565.9091"
+   height="1337.6713"
+   viewBox="0 0 1565.9091 1337.6713"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <marker
+       style="overflow:visible"
+       id="marker6"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="0.30000001"
+       markerHeight="0.5"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="none">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Triangle"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="1"
+       markerHeight="0.69999999"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="none">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6-6"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="0.30000001"
+       markerHeight="0.5"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="none">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6-6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Triangle-8"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="1"
+       markerHeight="0.69999999"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="none">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Triangle-8-9"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       markerWidth="1"
+       markerHeight="0.69999999"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="none">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135-2-8" />
+    </marker>
+  </defs>
+  <path
+     style="fill:none;stroke:#000000;stroke-width:18.8976;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6-6)"
+     d="M 754.80507,1059.2685 H 879.80505"
+     id="path5-4" />
+  <g
+     id="g47"
+     transform="translate(849.99925,606.37344)">
+    <g
+       id="g14"
+       style="fill:#b0b0b0;fill-opacity:1;stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 492.99351,159.62275 123.85471,21.95808 -123.73441,108.8271 z"
+         id="path8" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.97464,214.40148 18.99971,35.80993 -19.11132,95.20077 z"
+         id="path9" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.84822,181.58083 -0.05,130.86229 -123.68445,-22.03519 z"
+         id="path10" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 493.22536,420.69794 616.68665,443.45382 493.11526,290.08601 Z"
+         id="path11" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.68665,443.45382 0.11161,-131.0107 -123.683,-22.35711 z"
+         id="path12" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.79822,312.44312 78.06481,32.96906 -78.01481,-163.83135 z"
+         id="path13" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.86303,345.41218 0.11161,-131.0107 -77.97017,-33.0394 z"
+         id="path14" />
+    </g>
+    <g
+       id="g44"
+       style="stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.62978,330.0607 151.43187,7.81594 -151.31157,122.96924 z"
+         id="path15" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 -151.26161,-7.89305 z"
+         id="path16" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 155.87632,-4.27353 z"
+         id="path17" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 288.06165,337.87664 443.88797,464.4654 Z"
+         id="path18" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 136.86163,591.13589 287.90008,599.74963 136.75153,460.52396 Z"
+         id="path19" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 -151.26016,-8.21497 z"
+         id="path20" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 155.87628,-4.27353 z"
+         id="path21" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 287.90008,599.74963 443.88797,464.4654 Z"
+         id="path22" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.86163,591.13589 151.03845,8.61374 -151.02621,121.27698 z"
+         id="path23" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 287.90008,599.74963 288.0555,730.7312 136.87387,721.02661 Z"
+         id="path24" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.15542,130.98157 155.98105,-5.45296 z"
+         id="path25" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 444.13177,594.76089 -156.23169,4.98874 156.13647,125.52861 z"
+         id="path26" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 580.48863,315.23682 443.88797,464.4654 Z"
+         id="path27" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 -136.63638,18.69374 z"
+         id="path28" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 95.22515,-29.55818 z"
+         id="path29" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.63969,286.0325 -95.15106,29.20432 95.26088,100.97666 z"
+         id="path30" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 443.88797,464.4654 Z"
+         id="path31" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 443.88797,464.4654 Z"
+         id="path32" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 675.74955,416.21348 Z"
+         id="path33" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 444.03655,725.27824 Z"
+         id="path34" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 -137.83151,18.79469 z"
+         id="path35" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.64435,286.06868 38.33,-35.85727 -37.95713,165.67995 z"
+         id="path36" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 713.97435,250.21141 0.0248,129.76227 -37.98196,35.91768 z"
+         id="path37" />
+      <g
+         id="g39">
+        <path
+           style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+           d="m 675.80872,546.3354 -94.81214,29.70167 94.75293,-159.82359 z"
+           id="path38" />
+        <path
+           style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+           d="m 676.26102,546.18685 38.21039,-35.94776 -38.45419,-94.34773 z"
+           id="path39" />
+      </g>
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 -0.47218,-130.26541 -37.98201,35.91768 z"
+         id="path40" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 676.26102,546.18685 38.21039,-35.94776 -39.07265,166.6618 z"
+         id="path41" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 0.87148,130.44648 -39.94413,36.21532 z"
+         id="path42" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 93.5307,-29.58266 z"
+         id="path43" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.80872,546.3354 -94.81214,29.70167 94.40218,100.86382 z"
+         id="path44" />
+    </g>
+  </g>
+  <g
+     id="g2-3"
+     transform="translate(-136.00067,606.37344)">
+    <g
+       id="g4-5"
+       style="fill:#b0b0b0;fill-opacity:1;stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 492.99351,159.62275 123.85471,21.95808 -123.73441,108.8271 z"
+         id="path45945-48-9" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.97464,214.40148 18.99971,35.80993 -19.11132,95.20077 z"
+         id="path45945-48-4-8" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.84822,181.58083 -0.05,130.86229 -123.68445,-22.03519 z"
+         id="path45945-8-6-4" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 493.22536,420.69794 616.68665,443.45382 493.11526,290.08601 Z"
+         id="path45945-2-5-0" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.68665,443.45382 0.11161,-131.0107 -123.683,-22.35711 z"
+         id="path45945-8-3-0-7" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.79822,312.44312 78.06481,32.96906 -78.01481,-163.83135 z"
+         id="path45945-2-5-1-6" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.86303,345.41218 0.11161,-131.0107 -77.97017,-33.0394 z"
+         id="path45945-8-3-0-3-3" />
+    </g>
+    <g
+       id="g3-6"
+       style="stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.62978,330.0607 151.43187,7.81594 -151.31157,122.96924 z"
+         id="path45945-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 -151.26161,-7.89305 z"
+         id="path45945-8-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 155.87632,-4.27353 z"
+         id="path45945-8-1-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 288.06165,337.87664 443.88797,464.4654 Z"
+         id="path45945-8-1-2-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 136.86163,591.13589 287.90008,599.74963 136.75153,460.52396 Z"
+         id="path45945-2-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 -151.26016,-8.21497 z"
+         id="path45945-8-3-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 155.87628,-4.27353 z"
+         id="path45945-8-1-22-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 287.90008,599.74963 443.88797,464.4654 Z"
+         id="path45945-8-1-2-1-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.86163,591.13589 151.03845,8.61374 -151.02621,121.27698 z"
+         id="path45945-2-6-72" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 287.90008,599.74963 288.0555,730.7312 136.87387,721.02661 Z"
+         id="path45945-8-3-1-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.15542,130.98157 155.98105,-5.45296 z"
+         id="path45945-8-1-22-8-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 444.13177,594.76089 -156.23169,4.98874 156.13647,125.52861 z"
+         id="path45945-8-1-2-1-9-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 580.48863,315.23682 443.88797,464.4654 Z"
+         id="path45945-4-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 -136.63638,18.69374 z"
+         id="path45945-8-31-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 95.22515,-29.55818 z"
+         id="path45945-8-1-23-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.63969,286.0325 -95.15106,29.20432 95.26088,100.97666 z"
+         id="path45945-8-1-2-3-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 443.88797,464.4654 Z"
+         id="path45945-2-4-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 443.88797,464.4654 Z"
+         id="path45945-8-3-11-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 675.74955,416.21348 Z"
+         id="path45945-8-1-22-3-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 444.03655,725.27824 Z"
+         id="path45945-2-6-7-00" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 -137.83151,18.79469 z"
+         id="path45945-8-3-1-4-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.64435,286.06868 38.33,-35.85727 -37.95713,165.67995 z"
+         id="path45945-4-9-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 713.97435,250.21141 0.0248,129.76227 -37.98196,35.91768 z"
+         id="path45945-8-31-8-6" />
+      <g
+         id="g6-0">
+        <path
+           style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+           d="m 675.80872,546.3354 -94.81214,29.70167 94.75293,-159.82359 z"
+           id="path45945-8-1-2-1-8-7" />
+        <path
+           style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+           d="m 676.26102,546.18685 38.21039,-35.94776 -38.45419,-94.34773 z"
+           id="path45945-2-4-6-1" />
+      </g>
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 -0.47218,-130.26541 -37.98201,35.91768 z"
+         id="path45945-8-3-11-5-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 676.26102,546.18685 38.21039,-35.94776 -39.07265,166.6618 z"
+         id="path45945-2-6-7-0-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 0.87148,130.44648 -39.94413,36.21532 z"
+         id="path45945-8-3-1-4-2-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 93.5307,-29.58266 z"
+         id="path45945-8-1-22-8-2-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.80872,546.3354 -94.81214,29.70167 94.40218,100.86382 z"
+         id="path45945-8-1-2-1-9-7-3" />
+    </g>
+    <path
+       style="fill:none;stroke:#eb0000;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Triangle-8)"
+       d="m 676.0435,480.45652 151.71335,13.01561"
+       id="path4-3" />
+    <path
+       style="fill:none;stroke:#eb0000;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Triangle-8-9)"
+       d="m 676.10578,480.51759 115.6509,45.36575"
+       id="path4-3-2" />
+    <path
+       style="fill:none;stroke:#e10a0a;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 740.164,1207.9151 c 16.8317,-3.7504 32.52645,-8.0421 39.59798,-16.4402"
+       id="path7"
+       transform="translate(-0.0621768,-702.18545)" />
+  </g>
+  <path
+     style="fill:none;stroke:#000000;stroke-width:18.8976;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6)"
+     d="M 754.80507,382.18798 H 879.80505"
+     id="path5" />
+  <g
+     id="g3-8"
+     style="stroke-width:1.13386;stroke-dasharray:none"
+     transform="translate(857.87427,-98.609402)">
+    <g
+       id="g8">
+      <path
+         style="fill:#f8d9d9;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 377.36892,495.75684 335.41998,535.2123 377.36892,374.92877 Z"
+         id="path45945-8-1-2-1-35-9" />
+      <path
+         style="fill:#f8d9d9;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 377.36892,495.75684 40.64856,-37.62745 -40.64856,-83.20062 z"
+         id="path45945-2-4-8-6" />
+    </g>
+    <g
+       id="g7">
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 211.87387,407.1857 41.08871,-37.83724 -41.08871,158.62242 z"
+         id="path45945-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 252.96258,369.34846 v 121.88958 l -41.08871,36.73284 z"
+         id="path45945-8-12" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 252.96258,369.34846 v 121.88958 l 41.94894,-39.49069 z"
+         id="path45945-8-1-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,329.73717 -41.94894,39.61129 41.94894,82.39889 z"
+         id="path45945-8-1-2-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 211.87387,649.17881 41.08871,-37.14793 -41.08871,-84.38192 z"
+         id="path45945-2-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 252.96258,612.03088 V 491.23804 l -41.08871,36.41092 z"
+         id="path45945-8-3-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 252.96258,612.03088 V 491.23804 l 41.94894,-39.49069 z"
+         id="path45945-8-1-22-78" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,572.57542 -41.94894,39.45546 41.94894,-160.28353 z"
+         id="path45945-8-1-2-1-35" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 211.87387,649.17881 41.08871,-37.49168 -41.08871,158.12073 z"
+         id="path45945-2-6-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 252.96258,612.03088 v 120.50968 l -41.08871,37.61105 z"
+         id="path45945-8-3-1-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 252.96258,612.03088 v 120.50968 l 41.94894,-38.79287 z"
+         id="path45945-8-1-22-8-01" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,572.57542 -41.94894,38.43899 41.94894,82.73328 z"
+         id="path45945-8-1-2-1-9-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,329.73717 40.64856,-37.38145 -40.64856,159.39163 z"
+         id="path45945-4-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 335.56008,292.35572 v 121.78484 l -40.64856,37.60679 z"
+         id="path45945-8-31-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,572.57542 40.64856,-37.62745 -40.64856,-83.20062 z"
+         id="path45945-2-4-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 335.56008,534.94797 V 414.14056 l -40.64856,37.60679 z"
+         id="path45945-8-3-11-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 294.91152,572.57542 40.64856,-37.62745 -40.64856,158.79972 z"
+         id="path45945-2-6-7-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 335.56008,534.94797 v 121.2541 l -40.64856,37.54562 z"
+         id="path45945-8-3-1-4-14" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 418.06728,215.58245 v 121.88958 l 41.94894,-39.49069 z"
+         id="path45945-8-1-5-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,175.97116 -41.94894,39.61129 41.94894,82.39889 z"
+         id="path45945-8-1-2-0-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 418.06728,458.26487 V 337.47203 l 41.94894,-39.49069 z"
+         id="path45945-8-1-22-78-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,418.80941 -41.94894,39.45546 41.94894,-160.28353 z"
+         id="path45945-8-1-2-1-35-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 418.06728,458.26487 v 120.50968 l 41.94894,-38.79287 z"
+         id="path45945-8-1-22-8-01-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,418.80941 -41.94894,38.43899 41.94894,82.73328 z"
+         id="path45945-8-1-2-1-9-6-07" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 500.63774,138.63289 v 121.88958 l 41.94894,-39.49069 z"
+         id="path45945-8-1-5-2-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 542.58668,99.021603 -41.94894,39.611287 41.94894,82.39889 z"
+         id="path45945-8-1-2-0-8-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 500.63774,381.31531 V 260.52247 l 41.94894,-39.49069 z"
+         id="path45945-8-1-22-78-2-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 542.58668,341.85985 -41.94894,39.45546 41.94894,-160.28353 z"
+         id="path45945-8-1-2-1-35-8-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 500.63774,381.31531 v 120.50968 l 41.94894,-38.79287 z"
+         id="path45945-8-1-22-8-01-9-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 542.58668,341.85985 -41.94894,38.43899 41.94894,82.73328 z"
+         id="path45945-8-1-2-1-9-6-07-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,175.97116 40.64856,-37.38145 -40.64856,159.39163 z"
+         id="path45945-4-4-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 500.66478,138.58971 v 121.78484 l -40.64856,37.60679 z"
+         id="path45945-8-31-0-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,418.80941 40.64856,-37.62745 -40.64856,-83.20062 z"
+         id="path45945-2-4-8-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 500.66478,381.18196 V 260.37455 l -40.64856,37.60679 z"
+         id="path45945-8-3-11-9-86" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 460.01622,418.80941 40.64856,-37.62745 -40.64856,158.79972 z"
+         id="path45945-2-6-7-4-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 500.66478,381.18196 v 121.2541 l -40.64856,37.54562 z"
+         id="path45945-8-3-1-4-14-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 335.41998,292.52988 v 121.88958 l 41.94894,-39.49069 z"
+         id="path45945-8-1-5-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 377.36892,252.91859 -41.94894,39.61129 41.94894,82.39889 z"
+         id="path45945-8-1-2-0-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 335.41998,535.2123 V 414.41946 l 41.94894,-39.49069 z"
+         id="path45945-8-1-22-78-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 335.41998,535.2123 v 120.50968 l 41.94894,-38.79287 z"
+         id="path45945-8-1-22-8-01-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 377.36892,495.75684 -41.94894,38.43899 41.94894,82.73328 z"
+         id="path45945-8-1-2-1-9-6-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 377.36892,252.91859 40.64856,-37.38145 -40.64856,159.39163 z"
+         id="path45945-4-4-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 418.01748,215.53714 v 121.78484 l -40.64856,37.60679 z"
+         id="path45945-8-31-0-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 418.01748,458.12939 V 337.32198 l -40.64856,37.60679 z"
+         id="path45945-8-3-11-9-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 377.36892,495.75684 40.64856,-37.62745 -40.64856,158.79972 z"
+         id="path45945-2-6-7-4-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 418.01748,458.12939 v 121.2541 l -40.64856,37.54562 z"
+         id="path45945-8-3-1-4-14-4" />
+    </g>
+  </g>
+  <g
+     id="g2"
+     transform="translate(-136.06285,-95.812007)">
+    <g
+       id="g4"
+       style="fill:#b0b0b0;fill-opacity:1;stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 492.99351,159.62275 123.85471,21.95808 -123.73441,108.8271 z"
+         id="path45945-48" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.97464,214.40148 18.99971,35.80993 -19.11132,95.20077 z"
+         id="path45945-48-4" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.84822,181.58083 -0.05,130.86229 -123.68445,-22.03519 z"
+         id="path45945-8-6" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 493.22536,420.69794 616.68665,443.45382 493.11526,290.08601 Z"
+         id="path45945-2-5" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.68665,443.45382 0.11161,-131.0107 -123.683,-22.35711 z"
+         id="path45945-8-3-0" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 616.79822,312.44312 78.06481,32.96906 -78.01481,-163.83135 z"
+         id="path45945-2-5-1" />
+      <path
+         style="fill:#b0b0b0;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 694.86303,345.41218 0.11161,-131.0107 -77.97017,-33.0394 z"
+         id="path45945-8-3-0-3" />
+    </g>
+    <g
+       id="g6"
+       style="stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.80872,546.3354 -94.81214,29.70167 94.75293,-159.82359 z"
+         id="path45945-8-1-2-1-8" />
+      <path
+         style="fill:#fddcdc;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 676.26102,546.18685 38.21039,-35.94776 -38.45419,-94.34773 z"
+         id="path45945-2-4-6" />
+    </g>
+    <g
+       id="g3"
+       style="stroke-width:1.13386;stroke-dasharray:none">
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.62978,330.0607 151.43187,7.81594 -151.31157,122.96924 z"
+         id="path45945" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 -151.26161,-7.89305 z"
+         id="path45945-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 288.06165,337.87664 -0.05,130.86229 155.87632,-4.27353 z"
+         id="path45945-8-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 288.06165,337.87664 443.88797,464.4654 Z"
+         id="path45945-8-1-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 136.86163,591.13589 287.90008,599.74963 136.75153,460.52396 Z"
+         id="path45945-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 -151.26016,-8.21497 z"
+         id="path45945-8-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.11161,-131.0107 155.87628,-4.27353 z"
+         id="path45945-8-1-22" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 287.90008,599.74963 443.88797,464.4654 Z"
+         id="path45945-8-1-2-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.86163,591.13589 151.03845,8.61374 -151.02621,121.27698 z"
+         id="path45945-2-6" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 287.90008,599.74963 288.0555,730.7312 136.87387,721.02661 Z"
+         id="path45945-8-3-1" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 287.90008,599.74963 0.15542,130.98157 155.98105,-5.45296 z"
+         id="path45945-8-1-22-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 444.13177,594.76089 -156.23169,4.98874 156.13647,125.52861 z"
+         id="path45945-8-1-2-1-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 443.5151,334.64272 580.48863,315.23682 443.88797,464.4654 Z"
+         id="path45945-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 -136.63638,18.69374 z"
+         id="path45945-8-31" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.48863,315.23682 0.0357,130.53484 95.22515,-29.55818 z"
+         id="path45945-8-1-23" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.63969,286.0325 -95.15106,29.20432 95.26088,100.97666 z"
+         id="path45945-8-1-2-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 443.88797,464.4654 Z"
+         id="path45945-2-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 443.88797,464.4654 Z"
+         id="path45945-8-3-11" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 580.99658,576.03707 580.5244,445.77166 675.74955,416.21348 Z"
+         id="path45945-8-1-22-3" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 444.13177,594.76089 580.99658,576.03707 444.03655,725.27824 Z"
+         id="path45945-2-6-7" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 -137.83151,18.79469 z"
+         id="path45945-8-3-1-4" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.64435,286.06868 38.33,-35.85727 -37.95713,165.67995 z"
+         id="path45945-4-9" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 713.97435,250.21141 0.0248,129.76227 -37.98196,35.91768 z"
+         id="path45945-8-31-8" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 -0.47218,-130.26541 -37.98201,35.91768 z"
+         id="path45945-8-3-11-5" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 676.26102,546.18685 38.21039,-35.94776 -39.07265,166.6618 z"
+         id="path45945-2-6-7-0" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 714.47141,510.23909 0.87148,130.44648 -39.94413,36.21532 z"
+         id="path45945-8-3-1-4-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 580.99658,576.03707 0.87148,130.44648 93.5307,-29.58266 z"
+         id="path45945-8-1-22-8-2" />
+      <path
+         style="fill:#f6f6f6;fill-opacity:1;stroke:#000000;stroke-width:1.13386;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 675.80872,546.3354 -94.81214,29.70167 94.40218,100.86382 z"
+         id="path45945-8-1-2-1-9-7" />
+    </g>
+    <path
+       style="fill:none;stroke:#eb0000;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Triangle)"
+       d="M 676.0435,480.45652 805.83654,495.2399"
+       id="path4" />
+  </g>
+</svg>

--- a/proposals/physics_deformables/images/elementCollisionFilterGroups.svg
+++ b/proposals/physics_deformables/images/elementCollisionFilterGroups.svg
@@ -1,0 +1,7261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1079.58"
+   height="599.13"
+   viewBox="0 0 1079.58 599.13"
+   version="1.1"
+   id="svg920"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs920">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath928">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect929"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath929">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect930"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath930">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect931"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath931">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect932"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath932">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect933"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath933">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect934"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath934">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect935"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath935">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect936"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath936">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect937"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath937">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect938"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath938">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect939"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath939">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect940"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath940">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect941"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath941">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect942"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath942">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect943"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath943">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect944"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath944">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect945"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath945">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect946"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath946">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect947"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath947">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect948"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath948">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect949"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath949">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect950"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath950">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect951"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath951">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect952"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath952">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect953"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath953">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect954"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath954">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect955"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath955">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect956"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath956">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect957"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath957">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect958"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath958">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect959"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect960"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath960">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect961"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath961">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect962"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath962">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect963"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath963">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect964"
+         width="1200"
+         height="876.00006"
+         x="-2.6219643e-06"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath965">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect966"
+         width="1303.9143"
+         height="779.96112"
+         x="-1758.8873"
+         y="-759.40131"
+         transform="scale(-1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath966">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect967"
+         width="1303.9143"
+         height="779.96112"
+         x="-1758.8873"
+         y="-759.40131"
+         transform="scale(-1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath967">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect968"
+         width="1303.9143"
+         height="779.96112"
+         x="-1758.8873"
+         y="-759.40131"
+         transform="scale(-1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath968">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect969"
+         width="1303.9143"
+         height="779.96112"
+         x="-1758.8873"
+         y="-759.40131"
+         transform="scale(-1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath969">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect970"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath970">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect971"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect972"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath972">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect973"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath973">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect974"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath974">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect975"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath975">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect976"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath976">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect977"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath977">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect978"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath978">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect979"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath979">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect980"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath980">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect981"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath981">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect982"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath982">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect983"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect984"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath984">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect985"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath985">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect986"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath986">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect987"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath987">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect988"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath988">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect989"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath989">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect990"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath990">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect991"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath991">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect992"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath992">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect993"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath993">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect994"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect995"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath995">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect996"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath996">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect997"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath997">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect998"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath998">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect999"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath999">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1000"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1000">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1001"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1001">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1002"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1002">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1003"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1003">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1004"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1004">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1005"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1005">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1006"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1006">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1007"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1007">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1008"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1008">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1009"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1009">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1010"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1010">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1011"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1011">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1012"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1012">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1013"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1013">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1014"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1014">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1015"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1015">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1016"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1016">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1017"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1017">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1018"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1018">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1019"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1019">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1020"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1020">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1021"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1021">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1022"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1022">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1023"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1023">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1024"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1024">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1025"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1025">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1026"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1026">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1027"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1027">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1028"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1028">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1029"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1029">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1030"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1030">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1031"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1031">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1032"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1032">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1033"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1033">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1034"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1034">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1035"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1035">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1036"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1036">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1037"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1037">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1038"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1038">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1039"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1039">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1040"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1040">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1041"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1041">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1042"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1042">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1043"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1043">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1044"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1044">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1045"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1045">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1046"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1046">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1047"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1047">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1048"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1048">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1049"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1049">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1050"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1050">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1051"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1051">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1052"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1052">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1053"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1053">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1054"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1054">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1055"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1055">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1056"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1056">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1057"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1057">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1058"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1058">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1059"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1059">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1060"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1060">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1061"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1061">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1062"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1062">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1063"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1063">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1064"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1064">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1065"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1065">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1066"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1066">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1067"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1067">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1068"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1068">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1069"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1069">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1070"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1070">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1071"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1071">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1072"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1072">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1073"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1073">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1074"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1074">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1075"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1075">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1076"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1076">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1077"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1077">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1078"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1078">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1079"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1079">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1080"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1080">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1081"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1081">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1082"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1083"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1083">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1084"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1084">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1085"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1085">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1086"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1086">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1087"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1087">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1088"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1088">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1089"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1089">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1090"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1090">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1091"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1091">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1092"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1092">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1093"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1093">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1094"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1094">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1095"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1095">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1096"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1096">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1097"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1097">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1098"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1098">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1099"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1099">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1100"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1100">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1101"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1101">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1102"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1102">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1103"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1103">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1104"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1104">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1105"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1105">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1106"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1106">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1107"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1107">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1108"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1108">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1109"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1109">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1110"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1110">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1111"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1111">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1112"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1112">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1113"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1113">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1114"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1114">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1115"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1115">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1116"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1116">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1117"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1117">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1118"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1118">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1119"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1120"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1120">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1121"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1121">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1122"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1122">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1123"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1123">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1124"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1124">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1125"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1125">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1126"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1126">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1127"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1127">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1128"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1128">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1129"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1129">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1130"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1130">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1131"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1131">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1132"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1132">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1133"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1133">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1134"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1134">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1135"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1135">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1136"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1136">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1137"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1137">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1138"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1138">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1139"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1139">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1140"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1140">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1141"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1141">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1142"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1142">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1143"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1143">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1144"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1144">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1145"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1145">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1146"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1146">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1147"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1147">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1148"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1148">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1149"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1149">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1150"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1150">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1151"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1151">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1152"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1152">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1153"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1153">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1154"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1154">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1155"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1155">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1156"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1156">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1157"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1157">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1158"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1158">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1159"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1159">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1160"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1160">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1161"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1161">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1162"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1162">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1163"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1163">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1164"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1164">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1165"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1165">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1166"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1166">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1167"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1167">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1168"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1168">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1169"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1169">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1170"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1170">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1171"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1171">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1172"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1172">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1173"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1173">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1174"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1174">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1175"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1175">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1176"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1176">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1177"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1177">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1178"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1178">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1179"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1179">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1180"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1180">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1181"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1181">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1182"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1182">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1183"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1183">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1184"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1184">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1185"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1185">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1186"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1186">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1187"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1187">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1188"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1188">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1189"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1189">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1190"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1190">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1191"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1191">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1192"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1192">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1193"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1193">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1194"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1194">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1195"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1195">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1196"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1196">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1197"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1197">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1198"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1198">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1199"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1199">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1200"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1200">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1201"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1201">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1202"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1202">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1203"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1203">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1204"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1204">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1205"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1205">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1206"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1206">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1207"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1207">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1208"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1208">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1209"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1209">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1210"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1210">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1211"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1211">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1212"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1212">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1213"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1213">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1214"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1214">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1215"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1215">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1216"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1216">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1217"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1217">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1218"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1218">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1219"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1219">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1220"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1220">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1221"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1221">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1222"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1222">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1223"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1223">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1224"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1224">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1225"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1225">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1226"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1226">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1227"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1227">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1228"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1228">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1229"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1229">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1230"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1230">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1231"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1231">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1232"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1232">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1233"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1233">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1234"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1234">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1235"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1235">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1236"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1236">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1237"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1237">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1238"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1238">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1239"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1239">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1240"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1240">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1241"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1241">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1242"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1242">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1243"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1243">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1244"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1244">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1245"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1245">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1246"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1246">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1247"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1247">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1248"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1248">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1249"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1249">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1250"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1250">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1251"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1251">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1252"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1252">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1253"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1253">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1254"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1254">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1255"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1255">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1256"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1256">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1257"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1257">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1258"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1258">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1259"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1259">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1260"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1260">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1261"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1261">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1262"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1262">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1263"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1263">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1264"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1264">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1265"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1265">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1266"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1266">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1267"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1267">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1268"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1268">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1269"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1269">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1270"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1270">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1271"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1271">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1272"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1272">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1273"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1273">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1274"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1274">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1275"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1275">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1276"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1276">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1277"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1277">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1278"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1278">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1279"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1279">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1280"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1280">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1281"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1281">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1282"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1282">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1283"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1283">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1284"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1284">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1285"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1285">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1286"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1286">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1287"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1287">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1288"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1288">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1289"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1289">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1290"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1290">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1291"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1291">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1292"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1292">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1293"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1293">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1294"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1294">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1295"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1295">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1296"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1296">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1297"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1297">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1298"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1298">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1299"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1299">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1300"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1300">
+      <rect
+         style="fill:none;stroke:#339900;stroke-width:0"
+         id="rect1301"
+         width="1200"
+         height="876"
+         x="0"
+         y="0" />
+    </clipPath>
+  </defs>
+  <polygon
+     class="simulation_mesh"
+     points="1103.08,457.51 1102.01,397.54 1079.14,456.97 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon1"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1300)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1104.15,517.73 1103.08,457.51 1075.16,519.36 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon2"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1299)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1105.22,578.2 1104.15,517.73 1076.26,582.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon3"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1298)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1106.29,638.94 1105.22,578.2 1077.48,645.25 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon4"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1297)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1107.38,699.93 1106.29,638.94 1078.59,708.62 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon5"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1296)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1108.46,761.18 1107.38,699.93 1079.69,772.27 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon6"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1295)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1102.01,397.54 1071.49,395.35 1079.14,456.97 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon7"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1294)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1109.55,822.7 1108.46,761.18 1080.81,836.22 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon8"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1293)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1103.08,457.51 1079.14,456.97 1075.16,519.36 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon9"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1292)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1110.65,884.48 1109.55,822.7 1081.88,900.43 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon10"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1291)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1104.15,517.73 1075.16,519.36 1076.26,582.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon11"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1290)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1111.75,946.53 1110.65,884.48 1082.99,964.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon12"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath963)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1105.22,578.2 1076.26,582.16 1077.48,645.25 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon13"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1289)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1106.29,638.94 1077.48,645.25 1078.59,708.62 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon15"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1288)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1107.38,699.93 1078.59,708.62 1079.69,772.27 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon17"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1287)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1108.46,761.18 1079.69,772.27 1080.81,836.22 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon19"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1286)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1109.55,822.7 1080.81,836.22 1081.88,900.43 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon21"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1285)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1110.65,884.48 1081.88,900.43 1082.99,964.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon23"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath962)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1079.14,456.97 1071.49,395.35 1051.71,456.41 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon35"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1284)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1075.16,519.36 1079.14,456.97 1047.02,521.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon36"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1283)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1076.26,582.16 1075.16,519.36 1044.85,586.42 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon37"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1282)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1077.48,645.25 1076.26,582.16 1046.66,652.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon39"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1281)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1078.59,708.62 1077.48,645.25 1047.92,718.09 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon41"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1280)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1079.69,772.27 1078.59,708.62 1048.99,784.34 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon43"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1279)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1071.49,395.35 1037.84,393.51 1051.71,456.41 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon45"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1278)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1080.81,836.22 1079.69,772.27 1050.09,850.92 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon46"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1277)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1081.88,900.43 1080.81,836.22 1051.15,917.79 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon49"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1276)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1075.16,519.36 1047.02,521.32 1044.85,586.42 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon50"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1275)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1082.99,964.95 1081.88,900.43 1052.24,984.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon51"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath961)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1079.14,456.97 1051.71,456.41 1047.02,521.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon52"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1274)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1076.26,582.16 1044.85,586.42 1046.66,652.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon53"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1273)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1077.48,645.25 1046.66,652.11 1047.92,718.09 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon55"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1272)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1078.59,708.62 1047.92,718.09 1048.99,784.34 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon57"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1271)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1079.69,772.27 1048.99,784.34 1050.09,850.92 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon59"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1270)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1080.81,836.22 1050.09,850.92 1051.15,917.79 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon61"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1269)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1081.88,900.43 1051.15,917.79 1052.24,984.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon63"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath960)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1051.71,456.41 1037.84,393.51 1019.88,456.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon75"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1268)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1044.85,586.42 1047.02,521.32 1012.36,591.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon77"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1267)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1046.66,652.11 1044.85,586.42 1013.46,659.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon78"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1266)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1047.02,521.32 1051.71,456.41 1021.47,524.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon80"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1265)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1047.92,718.09 1046.66,652.11 1015,728.41 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon82"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1264)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1048.99,784.34 1047.92,718.09 1016.09,797.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon84"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1263)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1037.84,393.51 1001.35,391.86 1019.88,456.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon85"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1262)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1050.09,850.92 1048.99,784.34 1017.12,866.98 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon87"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1261)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1051.15,917.79 1050.09,850.92 1018.17,936.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon89"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1260)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1052.24,984.99 1051.15,917.79 1019.21,1006.89 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon90"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath958)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1044.85,586.42 1012.36,591.15 1013.46,659.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon91"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1259)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1047.02,521.32 1021.47,524.23 1012.36,591.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon92"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1258)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1051.71,456.41 1019.88,456.03 1021.47,524.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon94"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1257)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1046.66,652.11 1013.46,659.57 1015,728.41 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon95"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1256)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1047.92,718.09 1015,728.41 1016.09,797.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon97"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1255)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1048.99,784.34 1016.09,797.53 1017.12,866.98 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon99"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1254)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1050.09,850.92 1017.12,866.98 1018.17,936.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon101"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1253)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1051.15,917.79 1018.17,936.76 1019.21,1006.89 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon103"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath956)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1019.88,456.03 1001.35,391.86 983.67,455.98 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon115"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1252)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1013.46,659.57 1012.36,591.15 977.98,667.78 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon117"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1251)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1012.36,591.15 1021.47,524.23 979.37,596.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon119"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1250)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1015,728.41 1013.46,659.57 979.47,739.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon121"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1249)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1001.35,391.86 961.73,390.37 983.67,455.98 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon122"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1248)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1021.47,524.23 1019.88,456.03 991.16,527.09 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon123"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1247)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1016.09,797.53 1015,728.41 980.6,811.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon125"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1246)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1017.12,866.98 1016.09,797.53 981.56,884.58 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon127"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1245)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1018.17,936.76 1017.12,866.98 982.55,957.55 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon129"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1244)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1012.36,591.15 979.37,596.57 977.98,667.78 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon131"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1243)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1013.46,659.57 977.98,667.78 979.47,739.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon133"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1242)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1019.88,456.03 983.67,455.98 991.16,527.09 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon134"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1241)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1021.47,524.23 991.16,527.09 979.37,596.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon136"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1240)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1015,728.41 979.47,739.72 980.6,811.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon137"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1239)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1016.09,797.53 980.6,811.99 981.56,884.58 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon139"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1238)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="1017.12,866.98 981.56,884.58 982.55,957.55 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon141"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1237)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="983.67,455.98 961.73,390.37 942.77,456.5 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon152"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1236)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="961.73,390.37 918.96,388.77 942.77,456.5 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon158"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1235)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="977.98,667.78 979.37,596.57 940.39,676.94 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon159"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1234)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="979.47,739.72 977.98,667.78 941.05,752.17 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon161"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1233)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="979.37,596.57 991.16,527.09 943.35,602.55 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon162"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1232)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="980.6,811.99 979.47,739.72 942.09,827.88 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon164"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1231)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="991.16,527.09 983.67,455.98 956.91,530.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon165"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1230)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="981.56,884.58 980.6,811.99 943,903.96 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon167"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1229)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="982.55,957.55 981.56,884.58 943.9,980.44 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon169"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath953)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="979.37,596.57 943.35,602.55 940.39,676.94 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon172"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1228)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="977.98,667.78 940.39,676.94 941.05,752.17 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon173"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1227)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="983.67,455.98 942.77,456.5 956.91,530.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon174"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1226)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="979.47,739.72 941.05,752.17 942.09,827.88 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon176"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1225)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="991.16,527.09 956.91,530.07 943.35,602.55 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon178"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1224)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="980.6,811.99 942.09,827.88 943,903.96 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon179"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1223)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="981.56,884.58 943,903.96 943.9,980.44 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon181"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath952)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="942.77,456.5 918.96,388.77 895,458.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon190"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1222)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="918.96,388.77 872.63,387 895,458.57 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon196"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1221)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="940.39,676.94 943.35,602.55 899.51,687.1 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon199"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1220)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="941.05,752.17 940.39,676.94 899.4,765.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon201"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1219)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="943.35,602.55 956.91,530.07 903.46,609.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon203"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1218)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="942.09,827.88 941.05,752.17 900.14,845.47 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon204"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1217)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="956.91,530.07 942.77,456.5 918.04,533.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon205"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1216)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="943,903.96 942.09,827.88 900.95,925.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon207"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1215)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="943.9,980.44 943,903.96 901.73,1005.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon209"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath951)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="942.77,456.5 895,458.57 918.04,533.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon212"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1214)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="943.35,602.55 903.46,609.11 899.51,687.1 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon213"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1213)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="940.39,676.94 899.51,687.1 899.4,765.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon214"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1212)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="941.05,752.17 899.4,765.99 900.14,845.47 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon216"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1211)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="942.09,827.88 900.14,845.47 900.95,925.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon218"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1210)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="956.91,530.07 918.04,533.15 903.46,609.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon220"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1209)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="943,903.96 900.95,925.4 901.73,1005.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon221"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath950)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="895,458.57 872.63,387 847.97,458.48 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon227"
+     style="fill:#eec5a9;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1208)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="872.63,387 825.48,383.35 847.97,458.48 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon236"
+     style="fill:#eec5a9;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1207)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="862.6,401.38 831.06,362.09 850.08,362.46 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon238"
+     style="fill:#e08b54;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1206)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="899.51,687.1 903.46,609.11 854.52,698.39 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon241"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1205)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="899.4,765.99 899.51,687.1 853.72,781.37 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon242"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1204)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="850.08,362.46 831.06,362.09 879.97,337.39 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon244"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1203)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="900.14,845.47 899.4,765.99 854.14,865.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon245"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1202)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="918.04,533.15 895,458.57 873.45,536.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon246"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1201)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="903.46,609.11 918.04,533.15 859.02,616.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon248"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1200)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="900.95,925.4 900.14,845.47 854.79,949.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon250"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1199)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="843.5,400.97 831.06,362.09 862.6,401.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon251"
+     style="fill:#e08b54;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1198)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="895,458.57 847.97,458.48 873.45,536.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon254"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1197)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="831.06,362.09 859.43,336.87 879.97,337.39 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon257"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1196)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="899.51,687.1 854.52,698.39 853.72,781.37 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon258"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1195)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="903.46,609.11 859.02,616.32 854.52,698.39 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon259"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1194)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="899.4,765.99 853.72,781.37 854.14,865.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon260"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1193)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="900.14,845.47 854.14,865.03 854.79,949.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon263"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1192)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="918.04,533.15 873.45,536.16 859.02,616.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon266"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1191)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="811.28,361.72 838.06,336.25 831.06,362.09 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon270"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1190)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="831.06,362.09 838.06,336.25 859.43,336.87 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon272"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1189)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="847.97,458.48 825.48,383.35 795.9,458.37 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon275"
+     style="fill:#eec5a9;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1188)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="859.43,336.87 890.81,352.38 879.97,337.39 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon278"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1187)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="879.97,337.39 890.81,352.38 909.39,359.78 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon281"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1186)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="825.48,383.35 773.39,379.32 795.9,458.37 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon285"
+     style="fill:#eec5a9;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1185)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="859.43,336.87 838.06,336.25 890.81,352.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon289"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1184)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="854.52,698.39 859.02,616.32 804.48,710.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon291"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1183)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="853.72,781.37 854.52,698.39 803.23,798.54 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon293"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1182)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="909.39,359.78 890.81,352.38 919.68,398.3 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon294"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1181)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="873.45,536.16 847.97,458.48 823.55,539.43 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon295"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1180)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="854.14,865.03 853.72,781.37 803.35,886.9 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon296"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1179)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="859.02,616.32 873.45,536.16 809.41,624.31 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon298"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1178)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="854.79,949.23 854.14,865.03 803.78,975.86 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon300"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1177)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="847.97,458.48 795.9,458.37 823.55,539.43 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon303"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1176)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="838.06,336.25 869.5,347.29 890.81,352.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon304"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1175)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="890.81,352.38 905.41,387.25 919.68,398.3 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon306"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1174)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="854.52,698.39 804.48,710.95 803.23,798.54 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon308"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1173)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="859.02,616.32 809.41,624.31 804.48,710.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon309"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1172)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="853.72,781.37 803.23,798.54 803.35,886.9 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon310"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1171)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="919.68,398.3 908.25,425.51 915.69,438.67 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon312"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1170)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="854.14,865.03 803.35,886.9 803.78,975.86 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon313"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1169)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="873.45,536.16 823.55,539.43 809.41,624.31 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon316"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1168)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="905.41,387.25 908.25,425.51 919.68,398.3 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon317"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1167)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="915.69,438.67 908.25,425.51 905.58,476.91 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon321"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1166)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="890.81,352.38 890.56,375.61 905.41,387.25 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon322"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1165)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="869.5,347.29 890.56,375.61 890.81,352.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon323"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1164)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="795.9,458.37 773.39,379.32 740.18,457.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon326"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1163)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="905.41,387.25 890.56,375.61 908.25,425.51 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon334"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1162)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="773.39,379.32 717.33,373.86 740.18,457.15 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon335"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1161)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="908.25,425.51 903.04,462.84 905.58,476.91 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon336"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1160)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="905.58,476.91 895.88,498.11 891.4,512.02 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon339"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1159)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="903.04,462.84 895.88,498.11 905.58,476.91 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon342"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1158)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="804.48,710.95 809.41,624.31 748.59,725.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon344"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1157)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="890.56,375.61 898.17,411.63 908.25,425.51 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon345"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1156)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="803.23,798.54 804.48,710.95 746.96,817.82 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon346"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1155)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="891.4,512.02 895.88,498.11 877.25,544.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon347"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1154)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="823.55,539.43 795.9,458.37 767.79,543.13 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon348"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1153)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="803.35,886.9 803.23,798.54 746.75,911.47 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon350"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1152)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="809.41,624.31 823.55,539.43 753.89,633.26 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon352"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1151)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="803.78,975.86 803.35,886.9 746.93,1005.8 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon353"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath945)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="908.25,425.51 900.25,447.91 903.04,462.84 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon354"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1150)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="898.17,411.63 900.25,447.91 908.25,425.51 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon356"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1149)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="795.9,458.37 740.18,457.15 767.79,543.13 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon358"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1148)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="895.88,498.11 888.44,531.23 877.25,544.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon360"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1147)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="903.04,462.84 900.25,447.91 895.88,498.11 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon361"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1146)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="804.48,710.95 748.59,725.03 746.96,817.82 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon363"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1145)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="809.41,624.31 753.89,633.26 748.59,725.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon364"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1144)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="803.23,798.54 746.96,817.82 746.75,911.47 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon366"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1143)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="877.25,544.42 881.36,562.28 863.61,573.97 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon367"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1142)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="803.35,886.9 746.75,911.47 746.93,1005.8 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon368"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath944)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="888.44,531.23 881.36,562.28 877.25,544.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon370"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1141)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="823.55,539.43 767.79,543.13 753.89,633.26 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon373"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1140)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="900.25,447.91 900.79,483.25 895.88,498.11 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon376"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1139)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="863.61,573.97 881.36,562.28 850.81,600.6 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon377"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1138)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="740.18,457.15 717.33,373.86 677.71,455.77 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon380"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1137)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="895.88,498.11 900.75,517.33 888.44,531.23 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon383"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1136)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="900.79,483.25 900.75,517.33 895.88,498.11 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon387"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1135)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="717.33,373.86 654.57,367.67 677.71,455.77 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon391"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1134)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="888.44,531.23 900.75,517.33 881.36,562.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon392"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1133)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="881.36,562.28 873.94,590.83 850.81,600.6 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon393"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1132)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="850.81,600.6 865.97,616.77 838.24,623.78 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon397"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1131)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="748.59,725.03 753.89,633.26 685.75,740.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon399"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1130)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="746.96,817.82 748.59,725.03 683.73,839.63 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon400"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1129)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="873.94,590.83 865.97,616.77 850.81,600.6 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon401"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1128)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="767.79,543.13 740.18,457.15 705,547.35 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon403"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1127)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="746.75,911.47 746.96,817.82 683.2,939.27 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon404"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1126)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="900.75,517.33 900.46,549.97 881.36,562.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon406"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1125)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="753.89,633.26 767.79,543.13 691.23,643.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon407"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1124)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="746.93,1005.8 746.75,911.47 683.17,1039.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon408"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath943)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="881.36,562.28 899.24,580.96 873.94,590.83 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon410"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1123)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="838.24,623.78 865.97,616.77 825.64,643.44 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon411"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1122)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="740.18,457.15 677.71,455.77 705,547.35 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon413"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1121)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="900.46,549.97 899.24,580.96 881.36,562.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon414"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1120)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="748.59,725.03 685.75,740.95 683.73,839.63 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon417"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1119)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="873.94,590.83 899.24,580.96 865.97,616.77 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon418"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1118)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="753.89,633.26 691.23,643.32 685.75,740.95 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon419"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1117)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="746.96,817.82 683.73,839.63 683.2,939.27 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon421"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1116)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="865.97,616.77 855.82,638.51 825.64,643.44 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon422"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1115)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="746.75,911.47 683.2,939.27 683.17,1039.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon424"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath942)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="767.79,543.13 705,547.35 691.23,643.32 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon427"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1114)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="825.64,643.44 844.38,656.68 812,658.3 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon430"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1113)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="899.24,580.96 894.71,608.86 865.97,616.77 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon433"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1112)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="677.71,455.77 654.57,367.67 606.76,454.36 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon434"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1111)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="855.82,638.51 844.38,656.68 825.64,643.44 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon435"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1110)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="865.97,616.77 888.33,634.11 855.82,638.51 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon440"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1109)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="812,658.3 844.38,656.68 797.67,669.33 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon444"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1108)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="894.71,608.86 888.33,634.11 865.97,616.77 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon445"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1107)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="654.57,367.67 584.18,360.34 606.76,454.36 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon447"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1106)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="855.82,638.51 888.33,634.11 844.38,656.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon450"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1105)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="844.38,656.68 830.39,668.17 797.67,669.33 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon452"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1104)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="685.75,740.95 691.23,643.32 614.31,759.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon454"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1103)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="683.73,839.63 685.75,740.95 612.09,864.5 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon455"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1102)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="705,547.35 677.71,455.77 633.72,552.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon457"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1101)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="683.2,939.27 683.73,839.63 611.21,970.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon458"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1100)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="691.23,643.32 705,547.35 619.87,654.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon460"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1099)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="797.67,669.33 815.22,675.49 782,674.79 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon462"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1098)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="888.33,634.11 877.82,653.32 844.38,656.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon463"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1097)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="830.39,668.17 815.22,675.49 797.67,669.33 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon465"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1096)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="677.71,455.77 606.76,454.36 633.72,552.23 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon467"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1095)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="844.38,656.68 865.42,668.44 830.39,668.17 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon468"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1094)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="782,674.79 815.22,675.49 765.31,676.06 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon470"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1093)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="877.82,653.32 865.42,668.44 844.38,656.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon471"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1092)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="685.75,740.95 614.31,759.03 612.09,864.5 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon473"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1091)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="691.23,643.32 619.87,654.72 614.31,759.03 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon474"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1090)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="683.73,839.63 612.09,864.5 611.21,970.99 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon476"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1089)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="830.39,668.17 865.42,668.44 815.22,675.49 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon479"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1088)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="705,547.35 633.72,552.23 619.87,654.72 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon482"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1087)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="815.22,675.49 798.51,674.79 765.31,676.06 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon483"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1086)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="765.31,676.06 780.75,669.15 747.38,670.88 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon488"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1085)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="606.76,454.36 584.18,360.34 529.59,450.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon489"
+     style="fill:#abc5eb;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1084)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="865.42,668.44 850.18,674.32 815.22,675.49 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon493"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1083)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="798.51,674.79 780.75,669.15 765.31,676.06 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon494"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1082)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="747.38,670.88 780.75,669.15 728.15,660.94 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon499"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1081)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="815.22,675.49 833.67,675.08 798.51,674.79 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon501"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1080)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="584.18,360.34 507.58,349.69 529.59,450.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon502"
+     style="fill:#abc5eb;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1079)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="850.18,674.32 833.67,675.08 815.22,675.49 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon504"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1078)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="549.28,331.66 559.79,380.89 517.14,324.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon506"
+     style="fill:#5b91d8;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1077)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="581.05,296.64 549.28,331.66 517.14,324.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon508"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1076)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="798.51,674.79 833.67,675.08 780.75,669.15 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon509"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1075)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="780.75,669.15 762.45,654.98 728.15,660.94 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon510"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1074)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="614.31,759.03 619.87,654.72 532.44,779.75 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon512"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1073)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="612.09,864.5 614.31,759.03 530.05,893.06 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon513"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1072)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="633.72,552.23 606.76,454.36 552.01,557.89 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon515"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1071)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="611.21,970.99 612.09,864.5 528.92,1007.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon516"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1070)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="728.15,660.94 743.4,635.67 707.81,644.69 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon517"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1069)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="619.87,654.72 633.72,552.23 537.89,667.71 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon519"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1068)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="762.45,654.98 743.4,635.67 728.15,660.94 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon521"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1067)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="517.14,324.42 559.79,380.89 527.55,376.1 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon522"
+     style="fill:#5b91d8;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1066)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="833.67,675.08 816.41,665.2 780.75,669.15 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon524"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1065)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="707.81,644.69 743.4,635.67 686.58,622.75 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon526"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1064)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="550.78,287.38 581.05,296.64 517.14,324.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon527"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1063)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="606.76,454.36 529.59,450.53 552.01,557.89 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon528"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1062)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="780.75,669.15 798.47,649.71 762.45,654.98 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon529"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1061)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="816.41,665.2 798.47,649.71 780.75,669.15 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon531"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1060)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="614.31,759.03 532.44,779.75 530.05,893.06 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon533"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1059)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="619.87,654.72 537.89,667.71 532.44,779.75 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon534"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1058)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="762.45,654.98 798.47,649.71 743.4,635.67 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon536"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1057)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="612.09,864.5 530.05,893.06 528.92,1007.53 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon537"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1056)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="743.4,635.67 724.23,609.56 686.58,622.75 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon538"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1055)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="686.58,622.75 704.87,578.4 665.19,594.64 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon545"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1054)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="633.72,552.23 552.01,557.89 537.89,667.71 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon546"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1053)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="724.23,609.56 704.87,578.4 686.58,622.75 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon547"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1052)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="588.36,305.19 581.05,296.64 550.78,287.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon548"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1051)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="550.78,287.38 517.14,324.42 518.53,277.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon549"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1050)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="518.53,277.42 517.14,324.42 483.1,316.74 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon550"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1049)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="618.45,308.17 581.05,296.64 588.36,305.19 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon552"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1048)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="798.47,649.71 781.05,625.57 743.4,635.67 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon554"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1047)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="743.4,635.67 763.25,596.45 724.23,609.56 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon555"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1046)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="781.05,625.57 763.25,596.45 743.4,635.67 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon559"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1045)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="665.19,594.64 704.87,578.4 644.5,560.71 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon561"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1044)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="724.23,609.56 763.25,596.45 704.87,578.4 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon562"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1043)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="529.59,450.53 507.58,349.69 439.75,446.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon563"
+     style="fill:#abc5eb;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1042)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="704.87,578.4 685.71,542.28 644.5,560.71 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon569"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1041)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="763.25,596.45 745.63,561.83 704.87,578.4 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon570"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1040)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="648.65,344.14 618.45,308.17 588.36,305.19 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon571"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1039)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="704.87,578.4 727.35,523.74 685.71,542.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon573"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1038)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="745.63,561.83 727.35,523.74 704.87,578.4 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon574"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1037)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="588.36,305.19 550.78,287.38 518.53,277.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon575"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1036)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="685.71,542.28 667.19,501.48 644.5,560.71 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon576"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1035)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="507.58,349.69 418.8,337.35 439.75,446.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon578"
+     style="fill:#abc5eb;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1034)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="685.71,542.28 727.35,523.74 667.19,501.48 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon579"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1033)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="644.5,560.71 667.19,501.48 625.36,520.38 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon581"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1032)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="727.35,523.74 708.63,482.53 667.19,501.48 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon582"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1031)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="708.63,482.53 689.66,438.24 667.19,501.48 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon583"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1030)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="670.24,391.37 648.65,344.14 633.26,405.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon586"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1029)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="667.19,501.48 689.66,438.24 649.8,455.76 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon587"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1028)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="613.86,352.48 648.65,344.14 588.36,305.19 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon588"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1027)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="532.44,779.75 537.89,667.71 437.63,803.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon589"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1026)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="689.66,438.24 670.24,391.37 633.26,405.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon590"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1025)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="530.05,893.06 532.44,779.75 435.11,926.24 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon591"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1024)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="552.01,557.89 529.59,450.53 456.71,564.21 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon593"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1023)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="528.92,1007.53 530.05,893.06 433.72,1050.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon594"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath936)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="625.36,520.38 667.19,501.48 608.78,473.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon596"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1022)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="633.26,405.28 648.65,344.14 613.86,352.48 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon597"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1021)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="649.8,455.76 689.66,438.24 633.26,405.28 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon598"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1020)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="537.89,667.71 552.01,557.89 442.93,682.73 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon599"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1019)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="554.58,305.74 588.36,305.19 518.53,277.42 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon600"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1018)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="667.19,501.48 649.8,455.76 608.78,473.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon601"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1017)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="649.8,455.76 633.26,405.28 608.78,473.68 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon604"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1016)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="613.86,352.48 588.36,305.19 577.26,361.22 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon606"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1015)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="529.59,450.53 439.75,446.07 456.71,564.21 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon608"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1014)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="577.26,361.22 588.36,305.19 554.58,305.74 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon609"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1013)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="608.78,473.68 633.26,405.28 593.22,419.92 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon610"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1012)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="633.26,405.28 613.86,352.48 577.26,361.22 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon611"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1011)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="532.44,779.75 437.63,803.76 435.11,926.24 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon613"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1010)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="537.89,667.71 442.93,682.73 437.63,803.76 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon614"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1009)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="530.05,893.06 435.11,926.24 433.72,1050.07 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon616"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath934)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="593.22,419.92 633.26,405.28 577.26,361.22 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon617"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1008)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="552.01,557.89 456.71,564.21 442.93,682.73 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon620"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1007)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="439.75,446.07 418.8,337.35 333.83,440.91 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon631"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1006)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="418.8,337.35 316.3,321.59 333.83,440.91 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon638"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1005)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="437.63,803.76 442.93,682.73 326.6,831.94 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon641"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1004)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="435.11,926.24 437.63,803.76 323.96,965.3 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon642"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1003)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="456.71,564.21 439.75,446.07 344.47,571.34 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon644"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1002)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="442.93,682.73 456.71,564.21 331.73,700.3 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon647"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1001)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="439.75,446.07 333.83,440.91 344.47,571.34 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon652"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath1000)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="442.93,682.73 331.73,700.3 326.6,831.94 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon654"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath999)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="437.63,803.76 326.6,831.94 323.96,965.3 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon655"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath998)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="456.71,564.21 344.47,571.34 331.73,700.3 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon660"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath997)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="333.83,440.91 316.3,321.59 206.52,435.38 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon674"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath996)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="316.3,321.59 193.63,302.98 206.52,435.38 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon680"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath995)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="326.6,831.94 331.73,700.3 194.71,865.44 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon681"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath994)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="323.96,965.3 326.6,831.94 191.87,1011.96 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon682"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath993)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="344.47,571.34 333.83,440.91 210.91,579.6 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon684"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath992)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="331.73,700.3 344.47,571.34 199.69,721.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon685"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath991)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="333.83,440.91 206.52,435.38 210.91,579.6 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon692"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath990)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="331.73,700.3 199.69,721.11 194.71,865.44 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon694"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath989)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="326.6,831.94 194.71,865.44 191.87,1011.96 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon695"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath988)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="344.47,571.34 210.91,579.6 199.69,721.11 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon698"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath987)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="206.52,435.38 193.63,302.98 50.96,429.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon715"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath986)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="194.71,865.44 199.69,721.11 35.59,906.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon719"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath985)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="191.87,1011.96 194.71,865.44 32.17,1068.81 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon721"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath984)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="199.69,721.11 210.91,579.6 40.44,746.18 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon722"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath983)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="210.91,579.6 206.52,435.38 49.79,589.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon723"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath982)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="193.63,302.98 44.27,280.88 50.96,429.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon724"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath981)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="206.52,435.38 50.96,429.4 49.79,589.4 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon732"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath980)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="199.69,721.11 40.44,746.18 35.59,906.16 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon733"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath979)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="194.71,865.44 35.59,906.16 32.17,1068.81 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon735"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath978)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="simulation_mesh"
+     points="210.91,579.6 49.79,589.4 40.44,746.18 "
+     fill="#ffffff"
+     stroke="#9aa0a6"
+     id="polygon738"
+     style="stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath977)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="517.14,324.42 527.55,376.1 493.32,371.03 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon539"
+     style="fill:#5b91d8;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath976)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="483.1,316.74 517.14,324.42 493.32,371.03 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon542"
+     style="fill:#5b91d8;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath975)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="823.59,400.55 811.28,361.72 831.06,362.09 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon265"
+     style="fill:#e08b54;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath974)"
+     transform="translate(-31.620003,-276.87002)" />
+  <polygon
+     class="handle_twisted_01"
+     points="843.5,400.97 823.59,400.55 831.06,362.09 "
+     fill="#ffffff"
+     stroke="#13294b"
+     id="polygon261"
+     style="fill:#e08b54;fill-opacity:1;stroke-width:1.1;stroke-linejoin:round"
+     clip-path="url(#clipPath973)"
+     transform="translate(-31.620003,-276.87002)" />
+  <path
+     id="polygon921"
+     style="fill:#5b91d8;fill-opacity:1;stroke:#13294b;stroke-width:1.1;stroke-linejoin:round"
+     class="handle_twisted_01"
+     d="m 539.2185,433.93091 32.37987,1.67298 -11.85495,-54.53764 z"
+     clip-path="url(#clipPath972)"
+     transform="translate(-31.620003,-276.87002)" />
+  <path
+     id="polygon922"
+     style="fill:#5b91d8;fill-opacity:1;stroke:#13294b;stroke-width:1.1;stroke-linejoin:round"
+     class="handle_twisted_01"
+     d="m 527.46348,375.95189 11.87495,57.9597 20.47319,-52.99223 z"
+     clip-path="url(#clipPath971)"
+     transform="translate(-31.620003,-276.87002)" />
+  <path
+     id="polygon923"
+     style="fill:#5b91d8;fill-opacity:1;stroke:#13294b;stroke-width:1.1;stroke-linejoin:round"
+     class="handle_twisted_01"
+     d="m 493.38166,370.85798 46.10669,62.84372 -11.87892,-57.6783 z"
+     clip-path="url(#clipPath970)"
+     transform="translate(-31.620003,-276.87002)" />
+  <path
+     id="polygon924"
+     style="fill:#5b91d8;fill-opacity:1;stroke:#13294b;stroke-width:1.1;stroke-linejoin:round"
+     class="handle_twisted_01"
+     d="m 493.18862,370.80999 12.42329,62.3811 33.74192,0.6747 z"
+     clip-path="url(#clipPath969)"
+     transform="translate(-31.620003,-276.87002)" />
+  <path
+     id="polygon925"
+     style="fill:#e08b54;fill-opacity:1;stroke:#13294b;stroke-width:1.08196;stroke-linejoin:round"
+     class="handle_twisted_01"
+     transform="matrix(-0.9203059,0,0,-1.1231329,1587.0944,576.03855)"
+     d="m 827.41104,362.09 19.41096,0.15643 17.0812,40.73535 z"
+     clip-path="url(#clipPath968)" />
+  <path
+     id="polygon926"
+     style="fill:#e08b54;fill-opacity:1;stroke:#13294b;stroke-width:1.08196;stroke-linejoin:round"
+     class="handle_twisted_01"
+     transform="matrix(-0.9203059,0,0,-1.1231329,1587.0944,576.03855)"
+     d="M 827.48466,362.14718 863.9032,402.875 842.1968,402.57178 Z"
+     clip-path="url(#clipPath967)" />
+  <path
+     id="polygon927"
+     style="fill:#e08b54;fill-opacity:1;stroke:#13294b;stroke-width:1.08196;stroke-linejoin:round"
+     class="handle_twisted_01"
+     transform="matrix(-0.9203059,0,0,-1.1231329,1587.0944,576.03855)"
+     d="m 806.84912,361.39964 20.63555,0.76587 -5.84947,40.19984 z"
+     clip-path="url(#clipPath966)" />
+  <path
+     id="polygon928"
+     style="fill:#e08b54;fill-opacity:1;stroke:#13294b;stroke-width:1.08196;stroke-linejoin:round"
+     class="handle_twisted_01"
+     transform="matrix(-0.9203059,0,0,-1.1231329,1587.0944,576.03855)"
+     d="m 821.6352,402.15178 5.76522,-39.90429 15.05702,40.32429 z"
+     clip-path="url(#clipPath965)" />
+</svg>

--- a/proposals/physics_deformables/images/tet_restshape.svg
+++ b/proposals/physics_deformables/images/tet_restshape.svg
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1883.0123"
+   height="1146.7106"
+   viewBox="0 0 1883.0123 1146.7106"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g9"
+     transform="translate(-104.53243,-109.33368)">
+    <g
+       id="g3-05"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,-0.61193595)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-8" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-8" />
+    </g>
+    <g
+       id="g3-3-0"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,234.87295)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-1" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-3" />
+    </g>
+    <g
+       id="g3-3-2-2"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,470.35784)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4-2" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1-2" />
+    </g>
+    <g
+       id="g3-3-2-7-7"
+       style="fill:#ff7276;fill-opacity:1"
+       transform="translate(702.72065,705.84273)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4-4-0" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1-5-3" />
+    </g>
+    <g
+       id="g3-05-0"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,-0.61193595)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-8-9" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-8-5" />
+    </g>
+    <g
+       id="g3-3-0-5"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,234.87296)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-1-8" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-3-3" />
+    </g>
+    <g
+       id="g3-3-2-2-7"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,470.35785)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4-2-8" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1-2-3" />
+    </g>
+    <g
+       id="g3-3-2-7-7-7"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,705.84274)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4-4-0-9" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1-5-3-3" />
+    </g>
+  </g>
+  <g
+     id="g4"
+     transform="translate(-104.53243,-109.33368)">
+    <g
+       id="g3-0"
+       style="fill:#ff7276;fill-opacity:1;stroke-width:1.33138"
+       transform="matrix(0.75110221,0,0,0.75109842,326.964,167.7765)">
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:3.0192;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-42" />
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:3.0192;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-9" />
+    </g>
+    <g
+       id="g3-0-8"
+       style="fill:#ff7276;fill-opacity:1;stroke-width:1.33138"
+       transform="matrix(0.75110221,0,0,0.75109842,326.964,344.64883)">
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 406.33018,497.42796 v 176.87233 l 177.44013,0.28345 z"
+         id="path1-42-3"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-458.85975)" />
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 583.77031,497.42796 H 406.33018 l 177.44013,177.15578 z"
+         id="path1-7-9-2"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-458.85975)" />
+    </g>
+    <g
+       id="g3-0-8-5"
+       style="fill:#ff7276;fill-opacity:1;stroke-width:1.33138"
+       transform="matrix(0.75110221,0,0,0.75109842,326.964,521.52116)">
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 406.33018,674.30029 v 176.87233 l 177.44013,0.28345 z"
+         id="path1-42-3-4"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-694.34464)" />
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 583.77031,674.30029 H 406.33018 l 177.44013,177.15578 z"
+         id="path1-7-9-2-3"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-694.34464)" />
+    </g>
+    <g
+       id="g3-0-8-5-9"
+       style="fill:#ff7276;fill-opacity:1;stroke-width:1.33138"
+       transform="matrix(0.75110221,0,0,0.75109842,326.964,698.39349)">
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m 406.33018,851.17262 v 176.87228 l 177.44013,0.2835 z"
+         id="path1-42-3-4-9"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-929.82953)" />
+      <path
+         style="fill:#00afdb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 583.77031,851.17262 H 406.33018 l 177.44013,177.15578 z"
+         id="path1-7-9-2-3-2"
+         transform="matrix(1.3313767,0,0,1.3313834,-435.31226,-929.82953)" />
+    </g>
+    <g
+       id="g3"
+       style="fill:#ff7276;fill-opacity:1">
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1" />
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7" />
+    </g>
+    <g
+       id="g3-3"
+       style="fill:#ff7276;fill-opacity:1"
+       transform="translate(0,235.48489)">
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4" />
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1" />
+    </g>
+    <g
+       id="g3-3-2"
+       style="fill:#ff7276;fill-opacity:1"
+       transform="translate(0,470.96978)">
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4" />
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1" />
+    </g>
+    <g
+       id="g3-3-2-7"
+       style="fill:#ff7276;fill-opacity:1"
+       transform="translate(0,706.45467)">
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 105.66629,203.40761 V 438.8925 l 236.23965,0.37738 z"
+         id="path1-4-4-4" />
+      <path
+         style="fill:#ff7276;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M 341.90594,203.40761 H 105.66629 l 236.23965,235.86227 z"
+         id="path1-7-1-1-5" />
+    </g>
+  </g>
+  <g
+     id="g9-0"
+     transform="translate(1138.0779,-96.270967)"
+     style="opacity:1">
+    <g
+       id="g3-05-8"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,-0.61193595)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -269.61911,97.758317 -147.19668,274.337993 208.1143,70.82481 z"
+         id="path1-8-7" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M -101.35495,236.2688 -269.61911,97.758317 -208.70149,442.92112 Z"
+         id="path1-7-8-6" />
+    </g>
+    <g
+       id="g3-3-0-3"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,234.87295)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -416.81579,136.61142 -48.57197,299.07891 218.71335,-0.0717 z"
+         id="path1-4-1-5" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -208.70149,207.05885 -208.1143,-70.44743 170.14138,299.00722 z"
+         id="path1-7-1-3-6" />
+    </g>
+    <g
+       id="g3-3-2-2-5"
+       style="fill:#fcaebb;fill-opacity:1"
+       transform="translate(702.72065,470.35784)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -465.38776,200.20544 49.09997,296.32616 207.5863,-67.4852 z"
+         id="path1-4-4-2-83" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -246.67441,199.75637 -218.71335,0.44907 256.68627,228.84096 z"
+         id="path1-7-1-1-2-9" />
+    </g>
+    <g
+       id="g3-3-2-7-7-4"
+       style="fill:#ff7276;fill-opacity:1"
+       transform="translate(702.72065,705.84273)">
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M -416.28779,261.04671 -269.93687,536.25263 -98.191642,399.16179 Z"
+         id="path1-4-4-4-0-8" />
+      <path
+         style="fill:#fcaebb;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -208.70149,193.18413 -207.5863,67.86258 318.096148,138.11508 z"
+         id="path1-7-1-1-5-3-39" />
+    </g>
+    <g
+       id="g3-05-0-7"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,-0.61193595)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -337.5946,236.2688 -107.34654,206.27494 169.09569,57.96401 z"
+         id="path1-8-9-6" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M -195.35288,347.73503 -337.5946,236.2688 l 61.74915,264.23895 z"
+         id="path1-7-8-5-4" />
+    </g>
+    <g
+       id="g3-3-0-5-5"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,234.87296)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -444.94114,207.05885 -37.97292,228.18241 180.32426,-3.08518 z"
+         id="path1-4-1-8-8" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="M -275.84545,264.64548 -444.94114,207.05885 -302.5898,432.15608 Z"
+         id="path1-7-1-3-3-6" />
+    </g>
+    <g
+       id="g3-3-2-2-7-1"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,470.35785)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -482.91406,199.75637 37.97292,228.91265 169.21593,-65.44165 z"
+         id="path1-4-4-2-8-5" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -302.5898,196.29381 -180.32426,3.46256 207.18885,163.471 z"
+         id="path1-7-1-1-2-3-5" />
+    </g>
+    <g
+       id="g3-3-2-7-7-7-1"
+       style="fill:#c0e0ec;fill-opacity:1"
+       transform="translate(938.9603,705.84274)">
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -444.94114,193.18413 110.50985,205.60028 139.40091,-117.25313 z"
+         id="path1-4-4-4-0-9-9" />
+      <path
+         style="fill:#c0e0ec;fill-opacity:1;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+         d="m -275.72521,127.3651 -169.21593,65.81903 249.91076,88.34715 z"
+         id="path1-7-1-1-5-3-3-6" />
+    </g>
+  </g>
+  <circle
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     id="path9"
+     cx="237.37352"
+     cy="329.55884"
+     r="16.630081" />
+  <circle
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     id="path9-86"
+     cx="940.09418"
+     cy="329.45929"
+     r="16.630081" />
+  <circle
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     id="path9-86-4"
+     cx="1631.4824"
+     cy="345.05481"
+     r="16.630081" />
+  <circle
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     id="path9-8"
+     cx="300.66388"
+     cy="388.1218"
+     r="16.630081" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:2.26772;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:6.80315, 6.80315;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 237.37351,329.9362 64.42424,58.15808 v 0"
+     id="path10" />
+</svg>

--- a/proposals/physics_deformables/wp_deformable_physics.md
+++ b/proposals/physics_deformables/wp_deformable_physics.md
@@ -1,0 +1,904 @@
+# Deformable Body Physics in USD Proposal
+
+- [Purpose and Scope](#purpose-and-scope)
+- [Guiding Principles](#guiding-principles)
+- [USD Implementation](#usd-implementation)
+  - [Scenes](#scenes)
+  - [Rigid Body Refactor](#rigid-body-refactor)
+  - [Physics Material](#physics-material)
+  - [Deformable Materials](#deformable-materials)
+  - [Deformable Bodies](#deformable-bodies)
+  - [Simulation Geometry and Rest Shape](#simulation-geometry-and-rest-shape)
+  - [Rest Shape Attributes](#rest-shape-attributes)
+  - [Collision Geometries](#collision-geometries)
+  - [Graphics Geometries](#graphics-geometries)
+  - [Geometry Embeddings](#geometry-embeddings)
+  - [Assigning Materials](#assigning-materials)
+  - [Mass Distribution](#mass-distribution)
+  - [Kinematic Deformables](#kinematic-deformables)
+  - [Attachments](#attachments)
+  - [Element Collision Filtering](#element-collision-filtering)
+
+## Purpose and Scope
+
+After extending USD with the ability to express rigid body physics simulation concepts in 2021, the USD Physics working group has decided to prioritize further extending USD with concepts to express deformable body dynamics. This specification defines a similarly basic set of abstractions for expressing the initial conditions for the simulation of elastic deformation, including that of volumes, surfaces (e.g. cloth, shells) and curves (e.g. hair, strands). Concerns around plastic deformation were left for a future extension.
+
+Fewer generally available and commonly used tools and libraries exist for deformable simulation than for rigid body simulation, which made the search for a common set of abstractions more difficult. The same assumptions about target applications that were made for the USD Physics rigid bodies schema are made for deformables too: that the schema is primarily meant to serve interactive 3D graphics applications, and that users will be adding simulation capabilities to existing graphics-only USD content. A seamless extension of USD is intended, with the new simulation capabilities being made to interoperate with the existing rigid body abstractions, so that soft objects, cloth, hair, or fur can be represented and believably simulated.
+
+> **Design Note**
+>
+> Initially, it was planned to modify the original USD Physics schema for rigid bodies to integrate deformables in a way that included significant refactors of the existing schema to combine commonalities. Ultimately, the importance of formulating the USD Physics deformable bodies schema using minimal changes in a manner that preserves backwards compatibility was recognized. This approach ensures that both current and future applications can load existing assets as well as those that include deformables.
+
+## Guiding Principles
+
+As for the USD Physics rigid bodies schema, the intention was to focus on real-world concepts rather than on simulation-specific abstractions, unless those abstractions were overwhelmingly common and helpful. In particular, real-world engineering quantities are used for material properties. USD's preference for unit independence is maintained. The pattern established in the USD Physics rigid bodies schema is also continued, in which material properties are added to materials rather than to the simulated objects directly. The concept of physics scenes is retained. The USD design principle of preferring the use of existing classes or the addition of APIs to existing classes before introducing new prims is also adhered to.
+
+As with rigid bodies, all physics objects, now including deformables, automatically collide and interact by default.
+
+## USD Implementation
+
+### Scenes
+
+The USD Physics rigid bodies schema established the concept of physics scenes to enable multiple independent simulations within a single stage with different settings for fundamental properties such as gravity. Like rigid bodies, deformables conceptually simulate in a scene. Everything in a scene interacts by default, and things in different scenes do not interact. The gravity of a scene is applied to all the deformables in the scene. Deformables are associated with a scene in the same manner as rigid bodies, using the `simulationOwner` attribute.
+
+### Rigid Body Refactor
+
+The USD Physics rigid bodies schema introduced the `UsdPhysicsRigidBodyAPI` class. The member attributes `kinematicEnabled`, `simulationOwner`, and `startsAsleep` from this class can be reused for deformables; however, the `velocity` attributes are not needed on deformables as they generally have different local velocities at different points, and the `rigidBodyEnabled` attribute needs to be renamed to generalize it. To address this issue, a new pseudo-base class, `UsdPhysicsBodyAPI`, was created by splitting it out from `UsdPhysicsRigidBodyAPI` and moving the shared attributes to it. It is here referred to as a pseudo-base class because, in practice, API inheritance is no longer supported in USD. Therefore, `UsdPhysicsRigidBodyAPI` and `UsdPhysicsBodyAPI` are independent APIs which are both applied to a rigid body. To maintain backwards compatibility, `UsdPhysicsRigidBodyAPI` is extended with custom code to access the shared attributes now defined in `UsdPhysicsBodyAPI`. A new `bodyEnabled` attribute is introduced, and `rigidBodyEnabled` is retained for backwards compatibility.
+
+> **Design Note**
+>
+> To preserve existing content, `UsdPhysicsRigidBodyAPI` continues to support `rigidBodyEnabled` via custom accessors. Authoring the enable state through either API results in the corresponding value being written to the new `bodyEnabled` attribute, while reads resolve authored opinions from both attributes. Validators can be used to check consistency when both attributes have authored opinions. This approach leaves a clear path to deprecation of `rigidBodyEnabled`.
+
+```usda
+class "PhysicsBodyAPI"
+(
+    inherits = </APISchemaBase>
+)
+{
+    bool physics:bodyEnabled = true ()
+    bool physics:kinematicEnabled = false ()
+    rel physics:simulationOwner ()
+    uniform bool physics:startsAsleep = false ()
+}
+
+class "PhysicsRigidBodyAPI"
+(
+    inherits = </APISchemaBase>
+    prepend apiSchemas = ["PhysicsBodyAPI"]
+)
+{
+    bool physics:rigidBodyEnabled = true ()
+    vector3f physics:velocity = (0.0, 0.0, 0.0) ()
+    vector3f physics:angularVelocity = (0.0, 0.0, 0.0) ()
+}
+```
+
+### Physics Material
+
+The USD Physics rigid bodies schema introduced the `UsdPhysicsMaterialAPI` class, which includes attributes for density, surface friction (dynamic and static) and collision restitution. The density and surface friction attributes are reused for deformables. The restitution coefficient is not applicable to deformable abstractions, as their elasticity behavior is inherently simulated.
+
+```usda
+class "PhysicsMaterialAPI"
+(
+    inherits = </APISchemaBase>
+)
+{
+    float physics:dynamicFriction = 0.0 ()
+    float physics:staticFriction = 0.0 ()
+    float physics:restitution = 0.0 () # ignored for deformable bodies
+    float physics:density = 0.0 ()
+}
+```
+
+> **Design Note**
+>
+> The material of the USD Physics rigid bodies schema defines dynamic and static friction coefficients for the surface domain to which the material is applied. More specifically, they represent coefficients of an isotropic Coulomb friction model between two rigid bodies in contact, also commonly referred to as *dry friction*. Coulomb friction is generally independent of the relative tangential velocity of the rigid bodies at a given contact point, with the exception of static friction, which applies only when the tangential velocity is zero.
+>
+> Many rigid body and, even more commonly, deformable body simulators ignore static friction. Specifying it for both rigid and deformable surfaces is nevertheless well motivated, as the static friction coefficient is an integral aspect of the Coulomb friction model.
+>
+> It should be noted that simulators may support more sophisticated friction models via schema extensions.
+
+> **Design Note**
+>
+> In contrast to the refactor of the `UsdPhysicsRigidBodyAPI`, no common base material API is introduced. The existing `UsdPhysicsMaterialAPI` is reused directly for deformable bodies, with the `restitution` attribute documented as being ignored in that context. Introducing a dedicated base type to avoid this ambiguity would have required a new name — such as `UsdPhysicsBaseMaterialAPI` — as the `UsdPhysicsMaterialAPI` name is already taken, and its generic nature makes it suitable for direct reuse.
+>
+> The refactor of the `UsdPhysicsRigidBodyAPI` was better motivated: its rigid-body-specific name made it unsuitable for reuse as a common base, prompting the introduction of a new `UsdPhysicsBodyAPI`. This was reinforced by the presence of the `velocity` and `angularVelocity` attributes, which are not applicable to deformable bodies since these generally have different local velocities at different points.
+
+### Deformable Materials
+
+Three new material APIs are introduced: `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI`, each extending `UsdPhysicsMaterialAPI` with properties to specify the deformable behavior.
+
+The USD schema defines fallback values for unauthored attributes. Attributes with physical units depending on distance, time or mass use special fallback values called *sentinel values*, indicating that a suitable default is chosen by the simulator (hereafter referred to as a *simulator default*). This is necessary because appropriate values for such attributes depend on the stage's unit settings.
+
+`UsdPhysicsVolumeDeformableMaterialAPI` introduces the important engineering concepts of Young's modulus and Poisson's ratio as attributes:
+
+- `youngsModulus` has units of mass/(distance·seconds·seconds), equivalent to force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
+- `poissonsRatio` is unitless, has a range of [-1.0, 0.5], and a fallback value of 0.3.
+
+`UsdPhysicsSurfaceDeformableMaterialAPI` introduces properties for thin shells, including thickness and three distinct stiffness parameters for the deformation modes - stretch, shear, and bend:
+
+- `thickness` has units of distance, a range of (0, inf), and a fallback value of -inf (simulator default).
+- `stretchStiffness`, `shearStiffness`, `bendStiffness` have units of force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
+
+`UsdPhysicsCurvesDeformableMaterialAPI` introduces properties for deformable curves, including thickness and four distinct stiffness parameters for the deformation modes - stretch, shear, bend, and twist:
+
+- `thickness`, `stretchStiffness`, `shearStiffness`, `bendStiffness` as covered above.
+- `twistStiffness` has units of force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
+
+`UsdGeomBasisCurves`, the geometry type used for curve deformables, defines a `widths` attribute for rendering. The material's `thickness` parameter is intentionally separate, as the physical thickness that governs simulation behavior often needs to differ from the graphical width.
+
+The `thickness` attribute for surface and curve deformables is needed to compute masses based on material density.
+
+It is permitted to apply multiple physics material APIs to a single material. This makes it possible to use the material on both rigid objects and various types of deformable objects. For example, a general-purpose physics material instance, "rubberMaterial", can be defined by applying `UsdPhysicsMaterialAPI`, `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI` in combination. This means that e.g. the dynamic friction parameter has to be the same for rigid and deformable use cases. If this is a problem, the workaround is to create e.g. separate rigidRubber and deformableRubber materials.
+
+For details on deformable material assignment, see [Assigning Materials](#assigning-materials).
+
+```usda
+class "PhysicsVolumeDeformableMaterialAPI"
+(
+    inherits = </APISchemaBase>
+    prepend apiSchemas = ["PhysicsMaterialAPI"]
+)
+{
+    float physics:youngsModulus = -inf ()
+    float physics:poissonsRatio = 0.3 ()
+}
+
+class "PhysicsSurfaceDeformableMaterialAPI"
+(
+    inherits = </APISchemaBase>
+    prepend apiSchemas = ["PhysicsMaterialAPI"]
+)
+{
+    float physics:thickness = -inf ()
+    float physics:stretchStiffness = -inf ()
+    float physics:shearStiffness = -inf ()
+    float physics:bendStiffness = -inf ()
+}
+
+class "PhysicsCurvesDeformableMaterialAPI"
+(
+    inherits = </APISchemaBase>
+    prepend apiSchemas = ["PhysicsMaterialAPI"]
+)
+{
+    float physics:thickness = -inf ()
+    float physics:stretchStiffness = -inf ()
+    float physics:shearStiffness = -inf ()
+    float physics:bendStiffness = -inf ()
+    float physics:twistStiffness = -inf ()
+}
+```
+
+### Deformable Bodies
+
+The class `UsdPhysicsDeformableBodyAPI` is introduced to denote that a prim is to be deformable, whether volume-, surface-, or curve-based. Its pseudo-base class `UsdPhysicsBodyAPI` is also applied to any prim that has `UsdPhysicsDeformableBodyAPI` applied.
+
+```usda
+class "PhysicsDeformableBodyAPI"
+(
+    inherits = </APISchemaBase>
+    prepend apiSchemas = ["PhysicsBodyAPI"]
+)
+{
+    float physics:mass = 0.0 ()
+    float physics:density = 0.0 ()
+}
+```
+
+The pose of a rigid body is represented by the Xform defined through the USD transform hierarchy. Rigid bodies receive simulation updates on the Xform of their underlying `UsdGeomXformable` prim. In contrast, deformable objects do not have a single coordinate frame suitable for representing their configuration in space. Instead, they receive per-vertex state updates on a dedicated `UsdGeomPointBased` geometry, referred to as the "simulation geometry" (or "simulation mesh", where applicable).
+
+If a prim in a USD stage is marked with `UsdPhysicsRigidBodyAPI`, all prims in its subtree are considered part of the same rigid body and move rigidly with it. Likewise, all prims in the subtree of a prim marked with `UsdPhysicsDeformableBodyAPI` are considered part of the same deformable body. All `UsdGeomPointBased` prims within that subtree move and deform according to the motion of the deformable body's simulation geometry.
+
+An exception applies when a body's subtree (rigid or deformable) contains a nested prim with `UsdPhysicsBodyAPI`. This prim defines the root of a distinct rigid or deformable body. For all UsdPhysics purposes, this prim and its subtree are not considered part of the body higher in the hierarchy.
+
+The `UsdPhysicsDeformableBodyAPI` may be applied to any `UsdGeomImageable` prim that has no `UsdPhysicsRigidBodyAPI` applied to it. Two setup types are possible: the `UsdPhysicsDeformableBodyAPI` is applied to a suitable simulation geometry (explained in [Simulation Geometry and Rest Shape](#simulation-geometry-and-rest-shape)) to form a single-geometry deformable body, or to a `UsdGeomImageable` prim that has a direct simulation geometry child and may have other UsdGeomPointBased prims in its hierarchy.
+
+> **Design Note**
+>
+> It might seem obvious to apply the deformable body API to the simulation geometry and place it at the root of the deformable body hierarchy, similar to how the simulation state is represented in the rigid body hierarchy. However, as with rigid bodies, additional geometries used for graphics or collision detection are often desired to be placed beneath the deformable body root. Unfortunately, USD prohibits parenting a `UsdGeomGprim` under another `UsdGeomGprim`, making this arrangement impossible. Alternatively the simulation geometry must be parented under the deformable body root prim if other geometries are required. This arrangement leads to another problem. The simulation geometry needs to be clearly distinguished from other geometries, which is not always possible based on the geometry type alone. Therefore, a mandatory simulation API is required to differentiate the simulation geometry from other geometries. Furthermore, if the simulation geometry is not placed at the deformable body root, it is assumed to be a direct child of the `UsdPhysicsDeformableBodyAPI` prim.
+
+The `UsdPhysicsDeformableBodyAPI` has a `mass` and `density` attribute which, if defined, override the mass properties derived from material density as described in the section [Mass Distribution](#mass-distribution):
+
+- `mass` has units of mass, a range of (0, inf), and a fallback value of 0, indicating that it will be ignored for the mass distribution.
+- `density` has units of mass/(distance·distance·distance), a range of (0, inf), and a fallback value of 0, indicating that it will be ignored for the mass distribution.
+
+> **Design Note**
+>
+> It was decided to not support `UsdPhysicsMassAPI` for deformables, as it specifies the inertia tensor which is redundant for spatially discretized deformables. Factoring out inertia and center-of-mass attributes was considered, but was deemed unnecessary.
+
+> **Design Note**
+>
+> Using `UsdPhysicsDeformableBodyAPI` nesting under `UsdPhysicsRigidBodyAPI`, and vice versa, for the purpose of defining complex composite structures was contemplated. This would be useful to model parts such as bicycle wheels that have rigid and deformable components. It was decided against imposing such an interpretation of the USD hierarchy, as it would contradict how nested rigid bodies are interpreted—as independently moving. Further, implementations would need to generate attachments for such structures implicitly, which can already be achieved explicitly with this schema.
+
+### Simulation Geometry and Rest Shape
+
+The entire dynamic state of a rigid body is its pose in space and its instantaneous velocity. Both of these are captured in USD using the rigid body's transformation and velocity attributes. Joints between rigid bodies further capture the rest configuration of the connections they represent. This makes it possible to start simulating rigid bodies with nonzero initial velocities, and jointed configurations under initial load, i.e. making it possible to store out the entire state of a rigid body simulation to USD and continue the simulation later. For deformable simulation, both the dynamic state and the rest configuration need to be captured as well.
+
+The dynamic state is represented with a `UsdGeomPointBased` prim, here referred to as the "simulation geometry" (or "simulation mesh", where applicable). It has support for position state through its `points` attributes and velocity through its `velocities` attribute, both defined in the prim's local space. These attributes can be time-varying and, as such, if the previous velocity or previous position states are required to support higher order integration schemes, they can be obtained at a prior time sample.
+
+Depending on the type of deformable being modeled, a different geometry type and corresponding simulation API are required:
+
+- Volume deformable body requires a `UsdGeomTetMesh` with a `UsdPhysicsVolumeDeformableSimAPI`.
+- Surface deformable body requires a `UsdGeomMesh`, limited to triangular faces, with a `UsdPhysicsSurfaceDeformableSimAPI`.
+- Curve-based deformable body requires a `UsdGeomBasisCurves`, limited to linear segments, with a `UsdPhysicsCurvesDeformableSimAPI`. Because the simulation state of a curve also includes cross-section orientation, the `UsdGeomBasisCurves`' `normals` are required with `varying` or `vertex` interpolation: the normal at each vertex represents the cross-section orientation of the outgoing segment (the segment from that vertex to the next). Together with the segment tangent, this defines the segment's material frame, representing the simulator's twist and shear state. Adjacent material frames must be oriented within 180° of each other; multi-turn twist is not representable. The normal at the last vertex of a non-periodic curve has no associated outgoing segment and is unused.
+
+For volume deformables, a tetrahedral mesh is used to encode the simulation state. Even though some implementations might use other discretizations (e.g. hexahedral meshes), they must be converted to tetrahedral meshes.
+
+For curve deformables, individual segments need to be addressable. The number of segments per curve is computed from the `UsdGeomBasisCurves` topology via its `ComputeSegmentCounts` function, which uses the `curveVertexCounts` and `wrap` attributes. Specifically, segments are enumerated flatly across the primitive in curve order: for a curve whose vertices are v[*a*], …, v[*b*], the segments are (v[*i*], v[*i*+1]) for *i*=*a*,...,*b*-1, plus a closing segment (v[*b*], v[*a*]) when the curve is periodic (`wrap` set to `'periodic'`).
+
+The simulation APIs provide a `masses` attribute for specifying a per-point mass on the simulation geometry. When the `masses` attribute is specified, the size of the array must match the number of points defined in the simulation geometry's `points` attribute. These per-point mass definitions take precedence over any mass or density parameters specified by `UsdPhysicsDeformableBodyAPI` or `UsdPhysicsMaterialAPI`.
+
+The rest shape of a deformable body is represented by attributes of the type-specific simulation API, detailed in the following subsection.
+
+```usda
+class "PhysicsVolumeDeformableSimAPI"
+(
+    inherits = </APISchemaBase>
+)
+{
+    point3f[] physics:restShapePoints ()
+    int4[] physics:restTetVertexIndices ()
+    float[] physics:masses ()
+}
+
+class "PhysicsSurfaceDeformableSimAPI"
+(
+    inherits = </APISchemaBase>
+)
+{
+    point3f[] physics:restShapePoints ()
+    int3[] physics:restTriVertexIndices ()
+    uniform token physics:restBendAnglesDefault = "flat" ()
+    int2[] physics:restAdjTriPairs ()
+    float[] physics:restBendAngles ()
+    float[] physics:masses ()
+}
+
+class "PhysicsCurvesDeformableSimAPI"
+(
+    inherits = </APISchemaBase>
+)
+{
+    point3f[] physics:restShapePoints ()
+    normal3f[] physics:restNormals ()
+    float[] physics:masses ()
+}
+```
+
+### Rest Shape Attributes
+
+Rest shape is a fundamental concept for simulating deformable objects. A simulator employs some constitutive material model that computes restoring forces on simplices based on the difference between the rest shape and the current shape. Storing the rest configuration alongside the dynamic state is essential: without it, an elastic object that is draped or suspended under gravity would continue to stretch further each time the simulation is saved and restarted from USD. In more complex use cases, it may also be necessary for the rest shape to change over time.
+
+In the case of `UsdPhysicsVolumeDeformableSimAPI`, which is intended for tetmeshes, `restShapePoints` and `restTetVertexIndices` are specified. The rest shape always describes the same tetrahedral elements as the simulation mesh, in the same order: `restTetVertexIndices` must have the same length as the simulation `UsdGeomTetMesh`'s `tetVertexIndices`. The two index sets, however, reference different point arrays — `restTetVertexIndices` indexes into `restShapePoints`, while `tetVertexIndices` indexes into the simulation mesh's `points` — and the connectivity they express may differ. The rest shape's connectivity is unconstrained: tetrahedra may share vertices in the rest shape exactly as they do in the simulation mesh, share them in a different pattern, or not share them at all. This allows different portions of the tetmesh to have independent rest shapes. As a shortcut, when the rest connectivity matches the simulation connectivity exactly, `restTetVertexIndices` may be left empty and the simulation mesh's `tetVertexIndices` is used in its place; in this case, `restShapePoints` must contain the same number of points as the simulation mesh's `points`.
+
+<p align="center"><img src="images/tet_restshape.svg" alt="2D illustration of a volume deformable, showing a disconnected rest shape (left), the simulation mesh (middle), and the simulation mesh after simulation (right)." width="666"></p>
+
+*2D illustration of a volume deformable. The rest shape on the left consists of two disconnected parts with tetrahedra of different sizes. For this reason, the mesh describing the rest shape cannot have the same topology as the simulation mesh shown in the middle - some vertices of the simulation mesh correspond to disjoint vertices in the rest shape. The right-hand side shows the simulation mesh after the simulation.*
+
+This capability is more important in the case of `UsdPhysicsSurfaceDeformableSimAPI`, which is meant to be applied to surface meshes to represent cloth and shells. In modeling cloth, it is very common to define the planar rest shape of sections of the 3D mesh in a disjoint fashion in a 2D material "panel space." The `restShapePoints` attribute of `UsdPhysicsSurfaceDeformableSimAPI` has 3D points, but disjoint sets (w.r.t `restTriVertexIndices`) of these points can be coplanar to support planar rest shape descriptions from panel-based creation tools. Furthermore, this representation allows the description of the planar rest shape that should be compatible with models for 3D shells. As with the volume case, `restTriVertexIndices` may be left empty when the the rest connectivity matches the surface mesh's connectivity exactly, in which case the surface mesh's `faceVertexIndices` is used in its place and `restShapePoints` must contain the same number of points as the surface mesh's `points`.
+
+Thin shells (e.g. cloth) based on triangular meshes also require the definition of the rest dihedral angle for the interior edges of the mesh. Using the mesh of cloth pants as an example, one might want to describe a pleat along a consecutive edge run down the front of each leg. Besides increasing the `bendStiffness` for these edges, the `restBendAngles` for these edges could be set to something like 75 degrees. The assignment of `restBendAngles` is specified via `restAdjTriPairs`, pairs of adjacent triangles the dihedral bend angles refer to.
+
+The rest dihedral bend angles that are not explicitly specified are implicitly defined in two selectable ways. The attribute `restBendAnglesDefault` can be set to either `'flat'` or `'restShape'`. The former implies rest dihedral angles of zero degrees, which is useful for simulating cloth, for example. The latter implies rest angles based on the normals of the triangles, as defined by the rest shape points. This method is useful for simulating uneven 3D shells. The fallback value for `restBendAnglesDefault` is `'flat'`.
+
+<p align="center"><img src="images/defaul_dihedral_rest_angle2.svg" alt="Illustration of the effect of restBendAnglesDefault: 'flat' settles the mesh flat (top), 'restShape' settles it into the rest-shape dihedral angles (bottom)." width="632"></p>
+
+*Illustration showing the effect of `restBendAnglesDefault`. Using `flat`, which assumes dihedral angles of zero, causes the simulation mesh to settle into a flat shape (top). In contrast, using `restShape` results in the simulation mesh settling into a shape that corresponds to the dihedral angles defined by the triangle normals of the rest shape (bottom).*
+
+In defining rest dihedral bend angles, the adjacency is determined by the topology provided by the simulation `UsdGeomMesh`'s `faceVertexIndices`, rather than the rest shape's `restTriVertexIndices`, because the rest shape topology may describe disjoint sets of triangles.
+
+For `UsdPhysicsCurvesDeformableSimAPI`, the rest shape is specified through two attributes: `restShapePoints` and `restNormals`. Unlike for volume and surface deformables, no separate rest topology can be specified for curves. The rest topology is given by the simulation `UsdGeomBasisCurves`' `curveVertexCounts` and `wrap`.
+
+The rest centerline is specified by `restShapePoints`, with one rest position per simulation geometry vertex. Rest segment lengths and rest bend angles between adjacent segments are derived from these positions.
+
+The rest cross-section orientations are specified by `restNormals`, with one rest normal per simulation geometry vertex, interpreted in the rest configuration analogously to how `normals` is interpreted in the simulation state: each rest normal represents the rest cross-section orientation of the outgoing segment, defining the segment's rest material frame together with the rest segment tangent. Rest twist between adjacent segments is the relative rotation of their rest material frames around the segments' tangents. Rest shear, when modeled, is encoded by the rest material frame's orientation relative to the segment tangent.
+
+> **Design Note**
+>
+> The cross-section orientation of a curve deformable segment $(v_i, v_{i+1})$ is represented by the UsdGeomPointBased normal at $v_i$ – the same attribute used for graphics rendering. An alternative considered was a separate per-segment normal attribute, keeping the graphics normals available for rendering. This was dismissed to avoid introducing an additional per-segment attribute, on the assumption that rendering can be deferred to separate graphics geometries deformed by the simulation geometry when needed.
+
+> **Design Note**
+>
+> A limitation of `UsdPhysicsCurvesDeformableSimAPI` is that the rest length of the closing segment of a periodic curve and the rest bend angles at the wrap cannot be specified freely — they are implied by the positions of the first and last `restShapePoints`. As a result, it is not possible to describe a closed loop under tension. An earlier version of this proposal addressed this with a `restWrapPoints` attribute providing virtual rest points before the first and after the last vertex of each curve. It was decided not to include the attribute as the use case is uncommon. Future extensions may revisit this.
+
+> **Design Note**
+>
+> The rest shape could be represented as a separate `UsdGeomPointBased` geometry. This approach was dismissed for the following reasons:
+>
+> - The rest shape merely adds information to the elements already described by the simulation geometry, and is therefore intimately connected to it.
+> - In some cases the underlying geometry is not sufficient to represent all the required information. For example, the representation of rest angles between cloth panels (`restBendAngles`) would necessitate an additional API, which was deemed unnecessarily complex.
+
+### Collision Geometries
+
+Defining colliders for a deformable body works analogously to rigid bodies. `UsdGeomPointBased` geometries in the deformable body hierarchy can be marked with the `UsdPhysicsCollisionAPI`, which elects them to participate in collision detection. Deformable body colliders are limited to any `UsdGeomPointBased` prim because they need to be able to follow the deformable body's deformation. The collider geometries are embedded into the simulation geometry and contact forces/impulses computed against the colliders can be converted to constraints against the simulation geometry in the simulator. Embedding is supported through the `UsdPhysicsDeformablePoseAPI`, see section [Geometry Embeddings](#geometry-embeddings).
+
+> **Design Note**
+>
+> In the original design, the choice for which collision geometry to use was left entirely up to the implementation, anticipating different use-cases: some implementations would use high-fidelity approaches and use graphics geometries directly, while others might use a lower fidelity simulation geometry, or even an intermediate resolution transient approximation. Allowing the explicit mark up with `UsdPhysicsCollisionAPI` provides several advantages, however:
+>
+> - Better consistency with the approach used for rigid bodies. With explicit marking, it is, for example, possible to have no collision detection at all but still simulate the dynamics of the deformable.
+> - Providing the implementation with the approximation level intended by the application. One can choose to use the simulation geometry, a graphics geometry or a dedicated geometry used exclusively for collision detection. One could, for example, use a dedicated `UsdGeomPoints` prim and implement approximate collision detection by sampling the surface of a deformable using spheres.
+> - Allowing for schemes where the simulation geometry is entirely unsuitable for collision detection, for example using hexahedral meshes (represented as tets) as described in the section [Simulation Geometry and Rest Shape](#simulation-geometry-and-rest-shape) above. A dedicated geometry can then be used to represent the surface used for collision detection instead.
+
+Here is an example of a single geometry volume deformable body:
+
+```usda
+def TetMesh "volumeDeformable" (
+    prepend apiSchemas = [
+        "PhysicsDeformableBodyAPI",
+        "PhysicsVolumeDeformableSimAPI",
+        "PhysicsCollisionAPI"
+    ]
+) { ... }
+```
+
+<p align="center"><img src="images/collisionAPI_volA.svg" alt="2D illustration of a single geometry volume deformable; the tetrahedral mesh surface is used for collision detection." width="249"></p>
+
+*2D illustration of a single geometry volume deformable. The tetrahedral mesh surface is used for collision detection.*
+
+And here is an example of a volume deformable body using a specialized simulation geometry:
+
+```usda
+def Xform "volumeDeformable" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def TetMesh "simulationMesh" (
+        prepend apiSchemas = ["PhysicsVolumeDeformableSimAPI"]
+    ) { ... }
+
+    def Mesh "collisionMesh" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    ) { ... }
+
+    ...
+}
+```
+
+<p align="center"><img src="images/collisionAPI_volB.svg" alt="2D illustration of a deformable body with a hexahedral-structured tetrahedral simulation mesh (red) and a separate collision mesh (green)." width="364"></p>
+
+*2D illustration of a deformable body with a simulation mesh - here, a hexahedral-structured tetrahedral mesh (red) - and a separate collision mesh (green).*
+
+And here is another example for a surface deformable configured for collision detection using point samples:
+
+```usda
+def Xform "surfaceDeformable" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def Mesh "simulationMesh" (
+        prepend apiSchemas = ["PhysicsSurfaceDeformableSimAPI"]
+    ) { ... }
+
+    def Points "collisionGeom" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    ) { ... }
+
+    ...
+}
+```
+
+<p align="center"><img src="images/collisionAPI_surf.svg" alt="Surface deformable body with a triangle simulation mesh (red) and point sampling for collision detection (green)." width="459"></p>
+
+*Surface deformable body with a triangle simulation mesh (red) and point sampling for collision detection (green).*
+
+The following collision-related schemas interact with deformable body colliders as follows:
+
+- Group and pair filters as defined with `UsdPhysicsCollisionGroup` and `UsdPhysicsFilteredPairsAPI` directly apply to deformable body colliders.
+- `UsdPhysicsMassAPI` as supported for rigid body colliders will be ignored. Instead, non-uniform mass distributions across the simulation geometry can be expressed directly by specifying per-point masses or by using deformable material API bindings affecting the simulation geometry, see [Assigning Materials](#assigning-materials) and [Mass Distribution](#mass-distribution) for more details.
+
+Even though geometries are explicitly tagged to participate in collision detection, the implementation is still free to choose whether to create an intermediate representation for the collision geometry or geometries it uses internally. However, such an implicit approach has the disadvantage that the per-element collision filtering covered in the section [Element Collision Filtering](#element-collision-filtering) can't be applied. The `UsdPhysicsElementCollisionFilter` relies on explicit representation for deformable collision geometries in USD.
+
+### Graphics Geometries
+
+It should be recognized that often it is possible and desirable to simulate deformation at a lower discretization than used for rendering. For example, one might have a very detailed `UsdGeomMesh` of a car tire to capture all the geometric details of the treads carved into the running surface, made up of tens of thousands of triangles, but an approximate simulation of the stiff rubber material can be done using a volumetric mesh of less than a thousand elements. The simulation operates by deforming the volumetric mesh in response to gravity and collisions, and then deforming the graphics mesh by maintaining its embedding in the simulation mesh. Embedding is supported through the `UsdPhysicsDeformablePoseAPI`, see section [Geometry Embeddings](#geometry-embeddings).
+
+Geometries that are exclusively used for graphics are not particularly tagged but are rather identified by being hierarchically beneath the `UsdPhysicsDeformableBodyAPI` prim and not being marked with a simulation API nor with a collision API.
+
+The tire example would look something like this:
+
+```usda
+def Xform "tire" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def TetMesh "simulationMesh" (
+        prepend apiSchemas = [ "PhysicsVolumeDeformableSimAPI" ]
+    ) { ... }
+
+    def Mesh "collisionMesh" (
+        prepend apiSchemas = [ "PhysicsCollisionAPI" ]
+    ) { ... }
+
+    def Mesh "graphicsMesh" (
+        # to be deformed according to embedding in simulationMesh
+    ) { ... }
+
+    ...
+}
+```
+
+For surface deformables, the simulation mesh is of type `UsdGeomMesh`, but can still be discretized differently than the graphics mesh:
+
+```usda
+def Xform "surfaceDeformable" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def Mesh "simulationMesh" (
+        prepend apiSchemas = [
+            "PhysicsSurfaceDeformableSimAPI",
+            "PhysicsCollisionAPI"
+        ]
+    ) { ... }
+
+    def Mesh "graphicsMesh" (
+        # to be deformed according to embedding in simulationMesh
+    ) { ... }
+
+    ...
+}
+```
+
+For curve deformables, a similar pattern is followed:
+
+```usda
+def Xform "curvesDeformable" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def BasisCurves "simulationGeom" (
+        prepend apiSchemas = [
+            "PhysicsCurvesDeformableSimAPI",
+            "PhysicsCollisionAPI"
+        ]
+    ) { ... }
+
+    def BasisCurves "graphicsGeom" (
+        # to be deformed according to embedding in simulationGeom
+    ) { ... }
+
+    ...
+}
+```
+
+It is common in the case of hair/fur simulation to simulate only a subset of curves and use the simulation results to deform a much larger number of curves used for rendering.
+
+Pre-existing graphical assets often consist of multiple graphics meshes, for example, to facilitate easy assignment of graphics materials, and may be organized hierarchically. For example:
+
+```usda
+def Xform "rubberChickenToy" ()
+{
+    def Mesh "body" () { ... }
+    def Mesh "eyeballs" () { ... }
+    def Xform "left_leg" () {
+        def Mesh "left_leg" () { ... }
+        ...
+    }
+    def Xform "right_leg" () {
+        def Mesh "right_leg" () { ... }
+        ...
+    }
+    ...
+}
+```
+
+Marking such an asset for rigid body simulation would be relatively easy as follows: apply `UsdPhysicsRigidBodyAPI` to rubberChickenToy, apply `UsdPhysicsCollisionAPI` and `UsdPhysicsMeshCollisionAPI` to all meshes in the subtree. For deformable body simulation, a tool is assumed to apply the `UsdPhysicsDeformableBodyAPI` to the root, then generate a suitable simulation `UsdGeomTetMesh` with `UsdPhysicsVolumeDeformableSimAPI` that represents the entire volume occupied by the body, eyeballs, right and left legs of the chicken toy. If, for example, the generated simulation mesh is suitable for collision detection as well, it can be re-used as a collider by applying a `UsdPhysicsCollisionAPI`:
+
+```usda
+def Xform "rubberChickenToy" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def Mesh "body" () { ... }
+    def Mesh "eyeballs" () { ... }
+    def Xform "left_leg" () {
+        def Mesh "left_leg" () { ... }
+        ...
+    }
+    def Xform "right_leg" () {
+        def Mesh "right_leg" () { ... }
+        ...
+    }
+    def TetMesh "simulationMesh" (
+        prepend apiSchemas = [
+            "PhysicsVolumeDeformableSimAPI", "PhysicsCollisionAPI"
+        ]
+    ) { ... }
+    ...
+}
+```
+
+The simulator is responsible to embed the points of all graphical meshes into the volume described by the simulation mesh, which is covered in the next section. During simulation, the movement and deformation of the tetrahedra of the simulation mesh are governed by internal and external forces, while the embedded points of the graphical meshes are prescribed to move along the tetrahedra of the simulation mesh.
+
+Note that alternatively, the tool could also generate a separate collision mesh with `UsdPhysicsCollisionAPI` or apply a `UsdPhysicsCollisionAPI` per graphics mesh in the subtree. If the simulation mesh doubles as a collision mesh, no embedding is required. Separate collision meshes, however, need to be embedded, so they can follow the motion of the simulation mesh.
+
+### Geometry Embeddings
+
+In order to make a deformable body subtree move and deform consistently, the graphics and collision geometries must be embedded into the motion-guiding simulation geometry. The embedding defines for each point of the non-simulation geometries a mapping into the local coordinate space of the simulation geometry. As the simulation geometry deforms, the embedded geometries follow its motion through this mapping.
+
+The embedding is considered constant throughout the simulation for the purpose of this discussion. It is typically established in advance with respect to a reference configuration of both the embedded geometry and the simulation geometry, analogous to the *T-pose* used to determine skinning weights in character animation. This configuration is referred to as the *bind pose*.
+
+A relatively straightforward example of an embedding can be seen for volume deformables, when mapping the vertices of an embedded geometry $M$ to the tetrahedra of a simulation geometry $S$. In the *bind pose*, each point $p_i^{bind}$ of $M$ is located within one tetrahedron of $S$, identified as $\tau^{bind}(i)$ based on the simulation geometry's vertex positions $q_{i,0..3}^{bind}$. For this tetrahedron, the barycentric weights $\omega_{i,0..3}^{bind}$ are computed such that
+
+$$p_i^{bind} = \sum_{a=0}^{3} \omega_{i,a}^{bind}\, q_{i,a}^{bind}.$$
+
+During simulation, the embedded point is evaluated from the current state of $S$ using the precomputed data $\tau^{bind}(i)$ and $\omega_{i,0..3}^{bind}$:
+
+$$p_i^{t} = \sum_{a=0}^{3} \omega_{i,a}^{bind}\, q_{i,a}^{t}.$$
+
+This example illustrates only one possible embedding approach. In practice, numerous embedding techniques exist, each with its own trade-offs in accuracy, robustness, and computational cost, and differing across volume-, surface- and curve-based deformables. Because of this diversity, the USD Physics deformable bodies schema does not prescribe specific embedding mechanisms or their associated precomputed data, such as $\tau^{bind}(i)$ and $\omega_{i,0..3}^{bind}$ from the example above. Instead, it defines only the minimal necessary information — the *bind poses* — providing sufficient context for simulators to compute arbitrary embedding data and update embedded geometries during simulation.
+
+To facilitate the specification of auxiliary poses for deformable geometries, the `UsdPhysicsDeformablePoseAPI` is introduced. This API can be applied to any `UsdGeomPointBased` prim.
+
+```usda
+class "PhysicsDeformablePoseAPI"
+(
+    customData = {
+        token apiSchemaType = "multipleApply"
+        token propertyNamespacePrefix = "physics:deformablePose"
+    }
+    inherits = </APISchemaBase>
+)
+{
+    uniform token[] purposes ()
+    point3f[] points ()
+}
+```
+
+A *multiple-apply* API schema allows multiple distinct poses to be specified for a single deformable geometry. The `purposes` attribute enables reuse of the same pose for different purposes. This makes the API useful beyond defining the *bind pose* used for embeddings. For example, it can define a pose that assists in specifying an implicit deformable self-collision filter, or a pose at which a graphical mesh is processed to generate a suitable simulation or collision geometry. The `points` attribute stores the actual geometry configuration and must match the size of the `points` array of the `UsdGeomPointBased` prim to which the API is applied.
+
+A *bind pose* for a `UsdGeomPointBased` geometry can be specified by applying the `UsdPhysicsDeformablePoseAPI` and adding the `'bindPose'` token to its `purposes` attribute as well as storing the points representing the bind pose in the `points` attribute.
+
+If no *bind pose* has been specified for a `UsdGeomPointBased` geometry in the deformable subtree, the simulator is assumed to interpret the *authored default value* of the `points` attribute as the *bind pose*.
+
+The tire example from above is extended here with a custom `UsdPhysicsDeformablePoseAPI` that defines a `bindPose` purpose:
+
+```usda
+def Xform "tire" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    def TetMesh "simulationMesh" (
+        prepend apiSchemas = [
+            "PhysicsVolumeDeformableSimAPI",
+            "PhysicsDeformablePoseAPI:custom"
+        ]
+    ) {
+        token[] physics:deformablePose:custom:purposes = ["bindPose"]
+        point3f[] physics:deformablePose:custom:points = [...]
+        ...
+    }
+
+    def Mesh "collisionMesh" (
+        prepend apiSchemas = [
+            "PhysicsCollisionAPI",
+            "PhysicsDeformablePoseAPI:custom"
+        ]
+    ) {
+        token[] physics:deformablePose:custom:purposes = ["bindPose"]
+        point3f[] physics:deformablePose:custom:points = [...]
+        ...
+    }
+
+    def Mesh "graphicsMesh" (
+        prepend apiSchemas = [ "PhysicsDeformablePoseAPI:custom" ]
+    ) {
+        token[] physics:deformablePose:custom:purposes = ["bindPose"]
+        point3f[] physics:deformablePose:custom:points = [...]
+        ...
+    }
+
+    ...
+}
+```
+
+The `physics:deformablePose:custom:points` attributes of the 'simulationMesh', 'collisionMesh', and 'graphicsMesh' prims may be used by the simulator to compute embedding data. For example, when using the embedding method described above, each point of the 'graphicsMesh' bind pose can be located within a tetrahedron of the 'simulationMesh' bind pose, and the corresponding barycentric coordinates can then be computed, eliminating the need to represent the tetrahedra and barycentric weights explicitly in USD.
+
+### Assigning Materials
+
+The assignment of deformable materials follows the same principles as the assignment of rigid body materials. Physics materials are bound in the same way as graphics materials using the `UsdShadeMaterialBindingAPI`, either with no purpose qualifier or with a specific `'physics'` purpose. In the case of deformable materials two kinds of primitives can be affected:
+
+Simulation geometries, tagged with a deformable simulation API, are affected by `'dynamic'` properties
+
+- Density
+- Young's modulus
+- Poisson's ratio
+- Surface or curve thickness
+- Various stiffness parameters
+
+Collision geometries, tagged with the collision API, are affected by `'surface'` properties
+
+- Dynamic friction
+- Static friction
+
+Properties are by default propagated down the object tree to the simulation geometry and collision geometries. Additionally, materials can be bound to `UsdGeomSubset` prims of these geometries. Simulator implementations can use this feature, if they support sub-geometry element material assignments. For example, the non-uniform density of a volume deformable body may be inferred by reading the material densities of the simulation mesh's `UsdGeomSubset` prims with `'tetrahedron'` element type as described in section [Mass Distribution](#mass-distribution). `UsdPhysicsSurfaceDeformableMaterialAPI` `bendStiffness` values may be assigned to specific simulation mesh edges via a `UsdGeomSubset` using the `'edge'` element type.
+
+Deformable material densities are superseded by values specified through `UsdPhysicsDeformableBodyAPI:mass` and `density`, analogous to how rigid body material densities are superseded by `UsdPhysicsMassAPI` masses and densities. Additionally, material densities are also superseded by explicit per-point masses specified on the simulation geometry, such as `UsdPhysicsVolumeDeformableSimAPI:masses`.
+
+Example showing how to use a `UsdGeomSubset` prim in the previous rubber chicken toy setup to specify multi-material behavior.
+
+```usda
+def Material "softMat" (
+    prepend apiSchemas = [ "PhysicsVolumeDeformableMaterialAPI" ]
+) { ... }
+
+def Material "hardMat" (
+    prepend apiSchemas = [ "PhysicsVolumeDeformableMaterialAPI" ]
+) { ... }
+
+def Xform "rubberChickenToy" (
+    prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
+)
+{
+    # by default the soft material is used
+
+    rel material:binding:physics = </softMat> (
+        bindMaterialAs = "weakerThanDescendants"
+    )
+
+    def Mesh "body" () { ... }
+    def Mesh "eyeballs" () { ... }
+    def Xform "left_leg" () {
+        def Mesh "left_leg" () { ... }
+        ...
+    }
+    def Xform "right_leg" () {
+        def Mesh "right_leg" () { ... }
+        ...
+    }
+    def TetMesh "simulationMesh" (
+        prepend apiSchemas = [
+            "PhysicsVolumeDeformableSimAPI", "PhysicsCollisionAPI"
+        ]
+    ) {
+        # individual tetrahedra can use the hard material
+
+        def GeomSubset "subsetHard" (
+            prepend apiSchemas = ["MaterialBindingAPI"]
+        )
+        {
+            uniform token elementType = "tetrahedron"
+            uniform token familyName = "materialBind"
+            int[] indices = [...]
+            rel material:binding:physics = </hardMat> (
+                bindMaterialAs = "weakerThanDescendants"
+            )
+        }
+        ...
+    }
+    ...
+}
+```
+
+> **Design Note**
+>
+> Material properties assume discrete values. Variations across a single deformable geometry may be realized using multiple `UsdGeomSubset` prims. However, this approach is not practical for approximating a continuous variation of properties such as density, thickness, or stiffness. A natural extension would be to allow primvars to act as multipliers on material values, so that the effective value can be expressed as `value_effective = value_material * value_primvar`. For example, a primvar named `physics:densityScale` with vertex interpolation could scale the material density across the geometry, yielding a spatially varying mass distribution. This approach would complement rather than replace material based assignment. Such a mechanism is not currently part of the UsdPhysics specification but could serve as a future extension point.
+
+> **Design Note**
+>
+> Even though the USD Physics deformable bodies schema does not define how deformable materials affect graphics geometry, binding to graphics geometry can still be useful. Tools that generate simulation and collision geometry from graphics assets can use these bindings, including bindings on `UsdGeomSubset` prims, as hints for how to apply multiple materials to the generated simulation and collision geometry.
+
+### Mass Distribution
+
+For rigid bodies the specification of the mass distribution centers around `UsdPhysicsMaterialAPI`, `UsdPhysicsMassAPI` and geometries with `UsdPhysicsCollisionAPI`. The latter are used to define how mass is distributed. However, simulators may differ in how collision volumes are defined through `UsdPhysicsMeshCollisionAPI:approximation`, which also affects the effective mass distribution. For deformable bodies, mass is fundamentally a per-point quantity on the simulation geometry, which provides an opportunity to specify the mass distribution more definitively.
+
+The mass distribution can be authored at several levels, listed below in order of decreasing precedence. When an attribute is not authored, per-point masses are implicitly derived from a lower-precedence authored attribute using the formulas below.
+
+1. Per-point masses may be explicitly specified by the `masses` attribute given by `UsdPhysicsVolumeDeformableSimAPI`, `UsdPhysicsSurfaceDeformableSimAPI`, or `UsdPhysicsCurvesDeformableSimAPI`.
+
+2. `UsdPhysicsDeformableBodyAPI:mass`, the total mass of the body. Per-point masses are derived as
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = m_{tot}\, \frac{V_p}{V_{tot}}$
+
+   where $m_{tot}$ is the authored body mass, $V_p$ is the volume occupied by the point $p$ (defined below), and $V_{tot}$ is the total volume of the body, summed over all elements.
+
+3. `UsdPhysicsDeformableBodyAPI:density`. Per-point masses are derived as
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = \rho V_p$
+
+   where $\rho$ is the authored body density, $V_p$ is the volume occupied by the point $p$ (defined below).
+
+4. `UsdPhysicsMaterialAPI:density`, applied according to the binding rules described in [Assigning Materials](#assigning-materials). If a single density applies to the whole simulation geometry, this is equivalent to case 3. If different densities apply to subsets of elements via `UsdGeomSubset`, $V_p$ decomposes into contributions $V_p^{(i)}$ from elements bound to each material $i$, and the per-point mass is
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = \sum_i \rho_i V_p^{(i)}$
+
+   where $\rho_i$ is the density of material $i$. It therefore makes sense to restrict the `elementType` of the `UsdGeomSubset` for material mass properties assignment to:
+
+   - `'tetrahedron'`: for volume material `density`
+   - `'face'`: for surface material `density` and `thickness`
+   - `'segment'`: for curve material `density` and `thickness`
+
+The per-point volume $V_p$ is computed from the simulation geometry topology and the rest shape element volumes:
+
+$$V_p = \sum_{e\, \in\, \tau(p)} \frac{V_e}{T}$$
+
+where $\tau(p)$ is the set of elements adjacent to $p$ according to the simulation geometry connectivity, $V_e$ is the volume of elements $e$ evaluated based on the rest shape, and $T$ weights the contribution of a single element on its adjacent points:
+
+- For volume deformables, $V_e$ is the volume of a single tetrahedron, while $T$ is 4.
+- For surface deformables, $V_e = A_e d$, while $A_e$ is the area of a single triangle, $d$ is `UsdPhysicsSurfaceDeformableMaterialAPI:thickness`, and $T$ is 3.
+- For curve deformables, $V_e = L_e \frac{\pi d^2}{4}$, while $L_e$ is the length of a single segment, $d$ is `UsdPhysicsCurvesDeformableMaterialAPI:thickness`, and $T$ is 2.
+
+### Kinematic Deformables
+
+USD Physics permits a rigid body to be set to a kinematic state, and have its motion be animated, such that an instantaneous velocity based on the movement can be inferred. Such a body will act as an infinitely massive physics object and can push other dynamic physics objects out of the way. The same feature is also desirable for deformables. Kinematic deformables are marked using their `kinematicEnabled` attribute. The pose of the kinematic deformable body can be animated by setting the points of the simulation geometry or changing its transform. Additional collision or graphics geometries are animated by the simulator using the [embedding](#geometry-embeddings) into the simulation geometry.
+
+> **Design Note**
+>
+> The kinematicEnabled attribute applies to the deformable body as a whole – either the entire body is kinematic, or the entire body is dynamically simulated. Per-point or per-element kinematic state was left for a future extension.
+
+### Attachments
+
+Attachments between two deformable bodies or a deformable body and a `UsdGeomXformable` prim (for example, a rigid body or static collider) are supported. The objects being attached to each other are here referred to as 'attachment sources' and the location of the attachments are referred to as 'attachment sites'. A few basic rules apply:
+
+- Deformable attachment sources and corresponding geometry feature indices always refer to the simulation geometries, not the associated collision or graphics geometries of a deformable.
+- At least one of the sources needs to be a deformable simulation geometry.
+- Each attachment site on a deformable consists of a simulation geometry feature, such as a triangle, and local coordinates describing a location on or near the corresponding feature if applicable.
+- Each attachment site on a `UsdGeomXformable` source consists of a local position.
+- Each attachment consists of two sites, one for each source. Each site describes a single point regardless of site type. The simulator solves each attachment as a point-point constraint, such that the two points are pulled towards each other.
+- Self-attachment is allowed (both sources referring to the same deformable simulation geometry), provided the specified sites are suitably disjoint - e.g.: vertices should not be attached to themselves or adjacent faces.
+
+> **Design Note**
+>
+> Constraining two points does not constrain the relative orientation of the elements they belong to. Additional rotational degrees of freedom can be eliminated by authoring more attachments — their relative positions can implicitly fix orientation. The schema does not currently support specifying rotational coupling directly; this is left for a future extension.
+
+`UsdPhysicsAttachment` is a class representing a set of attachments between two sources (which may refer to the same prim in case of self-attachment):
+
+```usda
+class PhysicsAttachment "PhysicsAttachment"
+(
+    inherits = </Imageable>
+)
+{
+    bool physics:attachmentEnabled = true ()
+    rel physics:src0 ()
+    rel physics:src1 ()
+    uniform token physics:type0 (
+        allowedTokens = ["point", "face", "tetrahedron", "segment"]
+    )
+    uniform token physics:type1 (
+        allowedTokens = ["point", "face", "tetrahedron", "segment", "xform"]
+    )
+    int[] physics:indices0 ()
+    int[] physics:indices1 ()
+    vector3f[] physics:coords0 ()
+    vector3f[] physics:coords1 ()
+    float physics:stiffness = inf ()
+    float physics:damping = 0.0 ()
+}
+```
+
+- `attachmentEnabled`: Enables/disables the attachment.
+- `src0`, `src1`: Specify the source primitives. The `src0` relationship always refers to a deformable simulation geometry. The `src1` relationship either refers to a deformable simulation geometry (may be the same as `src0` for self-attachment) or an arbitrary `UsdGeomXformable` prim.
+- `type0`, `type1`: Specify the attachment site types for the corresponding sources. They define the kind of geometry feature the attachment sites refer to. The types need to be compatible with the corresponding sources as shown in the table below. The `type1` is set to `'xform'` for attachments to a rigid coordinate frame.
+- `indices0`, `indices1`: Specify the geometry feature indices for the sites. They are interpreted according to the type attributes and typically both arrays need to have the same number of elements, one per attachment site. There is one notable exception. In the case of attachments to `UsdGeomXformable` prims (i.e. `type1` is `'xform'`), `indices1` is empty.
+- `coords0`, `coords1`: Specify the local coordinates of the attachment sites relative to the corresponding site geometry feature described by `type0`, `indices0` or `type1`, `indices1` respectively. See the table below for how the coordinates are interpreted.
+- `stiffness`, `damping`: Specify the constitutive properties of all attachments in the set. The stiffness attribute specifies the strength of the attachment in units of force/area, and has a range of [0, inf), while a value of inf (simulator default) implies that the simulator should treat the constraint as hard if it is possible. The damping attribute only applies if the constraint isn't hard. Its specified in units of mass/second, has a range of [0, inf), and a fallback value 0.
+
+The following table shows the compatibility between sources and site types, as well as how indices and coordinates are interpreted.
+
+| type | src | indices | coords |
+|------|-----|---------|--------|
+| point | `UsdGeomBasisCurves`<br>`UsdGeomMesh`<br>`UsdGeomTetMesh` | vertex indices | N/A |
+| face | `UsdGeomMesh`<br>`UsdGeomTetMesh` (surface) | triangle indices | $(u, v, h)$ |
+| tetrahedron | `UsdGeomTetMesh` | tetrahedron indices | $(u, v, w)$ |
+| segment | `UsdGeomBasisCurves` | segment indices | $(u, s, t)$ |
+| xform | `UsdGeomXformable` | N/A | $(x, y, z)$ |
+
+The coordinates are interpreted according to site types as follows:
+
+- `point`: The attachment point $p$ is the position of the vertex at the given index. No coordinates are specified.
+
+- `face`: Each coordinate triple (`vector3f`) is interpreted as $(u, v, h)$, defined relative to the referenced triangle. The triangle's vertices are $x_0, x_1, x_2$, and its unit-length face normal is
+
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle \hat{n} = \pm\, \frac{(x_1 - x_0) \times (x_2 - x_0)}{\lVert (x_1 - x_0) \times (x_2 - x_0) \rVert}$
+
+  with the sign +1 for `rightHanded` orientation and -1 for `leftHanded`. The vertex order $(x_0, x_1, x_2)$ follows the triangle's authored vertex indices in the source mesh – `faceVertexIndices` for `UsdGeomMesh`, `surfaceFaceVertexIndices` for `UsdGeomTetMesh`. The components are interpreted as follows: $(u, v)$ are reduced barycentric coordinates that locate an arbitrary point in the plane containing the triangle; $h$ is a signed offset along $\hat{n}$. The attachment point $p$ is computed as
+
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle p = u x_0 + v x_1 + (1 - u - v) x_2 + h\hat{n}$
+
+- `tetrahedron`: Each coordinate triple (`vector3f`) is interpreted as $(u, v, w)$, defined relative to the referenced tetrahedron. The tetrahedron's vertices are $x_0, x_1, x_2, x_3$, ordered according to the source mesh's `tetVertexIndices` and `orientation` attributes. The components are interpreted as follows: $(u, v, w)$ are reduced barycentric coordinates that locate an arbitrary point in Euclidean space, relative to the referenced tetrahedron. The attachment point $p$ is computed as
+
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle p = u x_0 + v x_1 + w x_2 + (1 - u - v - w) x_3$
+
+- `segment`: Each coordinate triple (`vector3f`) is interpreted as $(u, s, t)$, defined relative to a coordinate frame on the referenced segment. The frame is built from the segment tangent $\hat{t}$, the segment normal $\hat{n}$, and the binormal $\hat{b}$:
+  - $\hat{t} = (x_1 - x_0) / \lVert (x_1 - x_0) \rVert$ is the unit segment tangent, where $x_0, x_1$ are the vertices of the referenced segment.
+  - $\hat{n} = (n - (n \cdot \hat{t})\hat{t}) / \lVert n - (n \cdot \hat{t})\hat{t} \rVert$ is the unit segment normal, obtained by projecting the curve simulation geometry normal $n$ (see [Simulation Geometry and Rest Shape](#simulation-geometry-and-rest-shape)) onto the plane orthogonal to $\hat{t}$ and normalizing. The projection is necessary because simulation normals are not constrained to be perpendicular to the segment tangent – they may encode shear as part of the material frame.
+  - $\hat{b} = ((x_1 - x_0) \times \hat{n}) / \lVert (x_1 - x_0) \times \hat{n} \rVert$ is the unit binormal.
+
+  The components are interpreted as follows: $u$ is a reduced barycentric coordinate (**not** a parametric coordinate) that locates an arbitrary point on the *line* containing the referenced segment; $(s, t)$ is an offset vector in the *plane* perpendicular to that line, expressed in the $(\hat{n}, \hat{b})$ basis. The attachment point $p$ is then computed as
+
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle p = u x_0 + (1 - u) x_1 + s\hat{n} + t\hat{b}$
+
+- `xform`: Each coordinate triple (`vector3f`) is interpreted as $(x, y, z)$, a local point in the coordinate frame described by the `UsdGeomXformable` prim.
+
+### Element Collision Filtering
+
+While `UsdPhysicsCollisionGroup` and `UsdPhysicsFilteredPairsAPI` allow for primitive-level collision filtering, which is also supported for deformable body colliders with `UsdPhysicsCollisionAPI`, `UsdPhysicsElementCollisionFilter` supports finer-grained filtering. The element-based filters support collision filtering between two deformable colliders and between deformable colliders and rigid body/static colliders. In the latter case, rigid body and static colliders are always filtered as a whole.
+
+Element-level filtering is needed particularly in the context of attachments, where collisions between the attached regions typically need to be suppressed to avoid conflicting constraints
+
+<p align="center"><img src="images/elementCollisionFilterGroups.svg" alt="Surface-surface deformable attachments requiring collision filtering, with a strap attached across a sheet." width="754"></p>
+
+*Surface-surface deformable attachments requiring collision filtering. Dark and light triangles of the same color form one group pair: the dark triangles on the strap and the light triangles on the sheet are filtered against each other at each attachment. All white triangles can still collide against each other, and blue and orange triangles can collide across colors.*
+
+The filtering always takes place at the level of the constituent elements of the deformable collision geometries they refer to:
+
+- Triangles for `UsdGeomMesh`
+- Surface triangles for `UsdGeomTetMesh`
+- Segments for `UsdGeomBasisCurves`
+- Points for `UsdGeomPoints`
+
+Not supported is filtering based on tetrahedral elements. It is assumed filtering collisions at the tetrahedral mesh surface is sufficient.
+
+```usda
+class PhysicsElementCollisionFilter "PhysicsElementCollisionFilter"
+(
+    inherits = </Imageable>
+)
+{
+    bool physics:filterEnabled = true ()
+    rel physics:src0 ()
+    rel physics:src1 ()
+    uint[] physics:groupElemCounts0 ()
+    uint[] physics:groupElemCounts1 ()
+    uint[] physics:groupElemIndices0 ()
+    uint[] physics:groupElemIndices1 ()
+}
+```
+
+- `filterEnabled`: Enables/disables the filter.
+- `src0`, `src1`: Specify the source primitives. Both must bear `UsdPhysicsCollisionAPI`. At least one must be a deformable body collider; the other may be either a deformable body collider or a rigid body/static collider. Self-filtering, with both sources referring to the same deformable collider, is supported.
+- `groupElemCounts0`, `groupElemCounts1`: Specify the sizes of paired element groups for each source. Corresponding entries pair up to define group-pairs of mutually filtered elements.
+- `groupElemIndices0`, `groupElemIndices1`: Specify the element indices belonging to each group, stored consecutively across all groups. Group boundaries are given by the corresponding group element counts array.
+
+Each pair of groups defines the elements of both colliders that should not collide with each other. E.g.: triangles [4, 5, 6] of one collider mesh are each not colliding against any triangles [12, 13] of the other collider mesh. The storage layout is analogous to how `faceVertexCounts` specifies the number of vertices per face and `faceVertexIndices` specifies the vertex indices per face in order. Two special cases:
+
+1. A group element count of 0 indicates that all elements of the corresponding collider are to be filtered against the matching group of the other collider.
+2. An empty list of group element counts indicates that all elements of the corresponding collider are filtered against all groups of the other collider. This is also the case in general for rigid body and static colliders, which are always filtered as a whole.
+
+#### Examples
+
+**Two groups each:**
+
+```usda
+groupElemCounts0 = [2, 1], groupElemIndices0 = [3, 4, 6]
+groupElemCounts1 = [2, 3], groupElemIndices1 = [9, 7, 2, 5, 6]
+```
+
+reads as:<br>
+element 3 and 4 of src0 are filtered against element 9 and 7 of src1,<br>
+element 6 of src0 is filtered against element 2, 5 and 6 of src1
+
+**Pairwise:**
+
+```usda
+groupElemCounts0 = [1, 1], groupElemIndices0 = [3, 4]
+groupElemCounts1 = [1, 1], groupElemIndices1 = [9, 7]
+```
+
+reads as:<br>
+element 3 of src0 is filtered against element 9 of src1,<br>
+element 4 of src0 is filtered against element 7 of src1
+
+**Mixed:**
+
+```usda
+groupElemCounts0 = [3, 2], groupElemIndices0 = [6, 7, 8, 15, 16]
+groupElemCounts1 = [0, 1], groupElemIndices1 = [33]
+```
+
+reads as:<br>
+element 6, 7 and 8 of src0 are filtered against all elements of src1,<br>
+element 15 and 16 of src0 are filtered against element 33 of src1
+
+**One group against all:**
+
+```usda
+groupElemCounts0 = [3], groupElemIndices0 = [3, 4, 6]
+groupElemCounts1 = [0], groupElemIndices1 = []
+```
+
+reads as:<br>
+element 3, 4 and 6 of src0 are filtered against all elements of src1

--- a/proposals/physics_deformables/wp_deformable_physics.md
+++ b/proposals/physics_deformables/wp_deformable_physics.md
@@ -49,7 +49,7 @@ The USD Physics rigid bodies schema introduced the `UsdPhysicsRigidBodyAPI` clas
 >
 > To preserve existing content, `UsdPhysicsRigidBodyAPI` continues to support `rigidBodyEnabled` via custom accessors. Authoring the enable state through either API results in the corresponding value being written to the new `bodyEnabled` attribute, while reads resolve authored opinions from both attributes. Validators can be used to check consistency when both attributes have authored opinions. This approach leaves a clear path to deprecation of `rigidBodyEnabled`.
 
-```usda
+```python
 class "PhysicsBodyAPI"
 (
     inherits = </APISchemaBase>
@@ -77,10 +77,11 @@ class "PhysicsRigidBodyAPI"
 
 The USD Physics rigid bodies schema introduced the `UsdPhysicsMaterialAPI` class, which includes attributes for density, surface friction (dynamic and static) and collision restitution. The density and surface friction attributes are reused for deformables. The restitution coefficient is not applicable to deformable abstractions, as their elasticity behavior is inherently simulated.
 
-```usda
+```python
 class "PhysicsMaterialAPI"
 (
     inherits = </APISchemaBase>
+
 )
 {
     float physics:dynamicFriction = 0.0 ()
@@ -139,7 +140,7 @@ Because these APIs are applied to the same primitive, their attributes share a s
 
 For details on deformable material assignment, see [Assigning Materials](#assigning-materials).
 
-```usda
+```python
 class "PhysicsVolumeDeformableMaterialAPI"
 (
     inherits = </APISchemaBase>
@@ -219,13 +220,14 @@ where $h$ is `curvesThickness`, $A = \pi h^2 / 4$ is the cross-section area (str
 
 The class `UsdPhysicsDeformableBodyAPI` is introduced to denote that a prim is to be deformable, whether volume-, surface-, or curve-based. Its pseudo-base class `UsdPhysicsBodyAPI` is also applied to any prim that has `UsdPhysicsDeformableBodyAPI` applied.
 
-```usda
+```python
 class "PhysicsDeformableBodyAPI"
 (
     inherits = </APISchemaBase>
     prepend apiSchemas = ["PhysicsBodyAPI"]
 )
 {
+
     float physics:mass = 0.0 ()
     float physics:density = 0.0 ()
 }
@@ -274,9 +276,9 @@ For curve deformables, individual segments need to be addressable. The number of
 
 The simulation APIs provide a `masses` attribute for specifying a per-point mass on the simulation geometry. When the `masses` attribute is specified, the size of the array must match the number of points defined in the simulation geometry's `points` attribute. These per-point mass definitions take precedence over any mass or density parameters specified by `UsdPhysicsDeformableBodyAPI` or `UsdPhysicsMaterialAPI`.
 
-The rest shape of a deformable body is represented by attributes of the type-specific simulation API, detailed in the following subsection.
+The rest shape of a deformable body may be represented by attributes of the type-specific simulation API, detailed in the following subsection.
 
-```usda
+```python
 class "PhysicsVolumeDeformableSimAPI"
 (
     inherits = </APISchemaBase>
@@ -313,15 +315,17 @@ class "PhysicsCurvesDeformableSimAPI"
 
 ### Rest Shape Attributes
 
-Rest shape is a fundamental concept for simulating deformable objects. A simulator employs some constitutive material model that computes restoring forces on simplices based on the difference between the rest shape and the current shape. Storing the rest configuration alongside the dynamic state is essential: without it, an elastic object that is draped or suspended under gravity would continue to stretch further each time the simulation is saved and restarted from USD. In more complex use cases, it may also be necessary for the rest shape to change over time.
+Rest shape is a fundamental concept for simulating deformable objects. A simulator employs some constitutive material model that computes restoring forces on simplices based on the difference between the rest shape and the current shape. Storing the rest configuration alongside the dynamic state is advantageous: without it, an elastic object that is draped or suspended under gravity would continue to stretch further each time the simulation is saved and restarted from USD. In more complex use cases, it may also be necessary for the rest shape to change over time.
 
-In the case of `UsdPhysicsVolumeDeformableSimAPI`, which is intended for tetmeshes, `restShapePoints` and `restTetVertexIndices` are specified. The rest shape always describes the same tetrahedral elements as the simulation mesh, in the same order: `restTetVertexIndices` must have the same length as the simulation `UsdGeomTetMesh`'s `tetVertexIndices`. The two index sets, however, reference different point arrays — `restTetVertexIndices` indexes into `restShapePoints`, while `tetVertexIndices` indexes into the simulation mesh's `points` — and the connectivity they express may differ. The rest shape's connectivity is unconstrained: tetrahedra may share vertices in the rest shape exactly as they do in the simulation mesh, share them in a different pattern, or not share them at all. This allows different portions of the tetmesh to have independent rest shapes. As a shortcut, when the rest connectivity matches the simulation connectivity exactly, `restTetVertexIndices` may be left empty and the simulation mesh's `tetVertexIndices` is used in its place; in this case, `restShapePoints` must contain the same number of points as the simulation mesh's `points`.
+None of the rest shape attributes are mandatory. Where they are not authored, the rest shape is derived from the simulation geometry, see [Rest Shape Fallbacks](#rest-shape-fallbacks).
+
+In the case of `UsdPhysicsVolumeDeformableSimAPI`, which is intended for tetmeshes, `restShapePoints` and `restTetVertexIndices` may be specified. The rest shape always describes the same tetrahedral elements as the simulation mesh, in the same order: `restTetVertexIndices` must have the same length as the simulation `UsdGeomTetMesh`'s `tetVertexIndices`. The two index sets, however, reference different point arrays — `restTetVertexIndices` indexes into `restShapePoints`, while `tetVertexIndices` indexes into the simulation mesh's `points` — and the connectivity they express may differ. The rest shape's connectivity is unconstrained: tetrahedra may share vertices in the rest shape exactly as they do in the simulation mesh, share them in a different pattern, or not share them at all. This allows different portions of the tetmesh to have independent rest shapes. When the rest connectivity matches the simulation connectivity exactly, `restTetVertexIndices` need not be authored, see [Rest Shape Fallbacks](#rest-shape-fallbacks).
 
 <p align="center"><img src="images/tet_restshape.svg" alt="2D illustration of a volume deformable, showing a disconnected rest shape (left), the simulation mesh (middle), and the simulation mesh after simulation (right)." width="666"></p>
 
 *2D illustration of a volume deformable. The rest shape on the left consists of two disconnected parts with tetrahedra of different sizes. For this reason, the mesh describing the rest shape cannot have the same topology as the simulation mesh shown in the middle - some vertices of the simulation mesh correspond to disjoint vertices in the rest shape. The right-hand side shows the simulation mesh after the simulation.*
 
-This capability is more important in the case of `UsdPhysicsSurfaceDeformableSimAPI`, which is meant to be applied to surface meshes to represent cloth and shells. In modeling cloth, it is very common to define the planar rest shape of sections of the 3D mesh in a disjoint fashion in a 2D material "panel space." The `restShapePoints` attribute of `UsdPhysicsSurfaceDeformableSimAPI` has 3D points, but disjoint sets (w.r.t `restTriVertexIndices`) of these points can be coplanar to support planar rest shape descriptions from panel-based creation tools. Furthermore, this representation allows the description of the planar rest shape that should be compatible with models for 3D shells. As with the volume case, `restTriVertexIndices` may be left empty when the the rest connectivity matches the surface mesh's connectivity exactly, in which case the surface mesh's `faceVertexIndices` is used in its place and `restShapePoints` must contain the same number of points as the surface mesh's `points`.
+This capability is more important in the case of `UsdPhysicsSurfaceDeformableSimAPI`, which is meant to be applied to surface meshes to represent cloth and shells. In modeling cloth, it is very common to define the planar rest shape of sections of the 3D mesh in a disjoint fashion in a 2D material "panel space." The `restShapePoints` attribute of `UsdPhysicsSurfaceDeformableSimAPI` has 3D points, but disjoint sets (w.r.t `restTriVertexIndices`) of these points can be coplanar to support planar rest shape descriptions from panel-based creation tools. Furthermore, this representation allows the description of the planar rest shape that should be compatible with models for 3D shells. As with the volume case, `restTriVertexIndices` need not be authored when the rest connectivity matches the surface mesh's connectivity exactly, see [Rest Shape Fallbacks](#rest-shape-fallbacks).
 
 Thin shells (e.g. cloth) based on triangular meshes also require the definition of the rest dihedral angle for the interior edges of the mesh. Using the mesh of cloth pants as an example, one might want to describe a pleat along a consecutive edge run down the front of each leg. Besides increasing the `surfaceBendStiffness` for these edges, the `restBendAngles` for these edges could be set to something like 75 degrees. The assignment of `restBendAngles` is specified via `restAdjTriPairs`, pairs of adjacent triangles the dihedral bend angles refer to.
 
@@ -333,7 +337,7 @@ The rest dihedral bend angles that are not explicitly specified are implicitly d
 
 In defining rest dihedral bend angles, the adjacency is determined by the topology provided by the simulation `UsdGeomMesh`'s `faceVertexIndices`, rather than the rest shape's `restTriVertexIndices`, because the rest shape topology may describe disjoint sets of triangles.
 
-For `UsdPhysicsCurvesDeformableSimAPI`, the rest shape is specified through two attributes: `restShapePoints` and `restNormals`. Unlike for volume and surface deformables, no separate rest topology can be specified for curves. The rest topology is given by the simulation `UsdGeomBasisCurves`' `curveVertexCounts` and `wrap`.
+For `UsdPhysicsCurvesDeformableSimAPI`, the rest shape may be specified through two attributes: `restShapePoints` and `restNormals`. Unlike for volume and surface deformables, no separate rest topology can be specified for curves. The rest topology is given by the simulation `UsdGeomBasisCurves`' `curveVertexCounts` and `wrap`.
 
 The rest centerline is specified by `restShapePoints`, with one rest position per simulation geometry vertex. Rest segment lengths and rest bend angles between adjacent segments are derived from these positions.
 
@@ -354,6 +358,20 @@ The rest cross-section orientations are specified by `restNormals`, with one res
 > - The rest shape merely adds information to the elements already described by the simulation geometry, and is therefore intimately connected to it.
 > - In some cases the underlying geometry is not sufficient to represent all the required information. For example, the representation of rest angles between cloth panels (`restBendAngles`) would necessitate an additional API, which was deemed unnecessarily complex.
 
+#### Rest Shape Fallbacks
+
+None of the rest shape attributes are mandatory. Where one is not authored, it is derived from the corresponding attribute of the simulation geometry, which must then have a value authored at the *default time code*.
+
+- `restShapePoints` is derived from the simulation geometry's `points`. An authored rest topology must then match the simulation geometry's topology.
+- `restTetVertexIndices` is derived from the `UsdGeomTetMesh`'s `tetVertexIndices`. An authored `restShapePoints` must then contain the same number of points as the `UsdGeomTetMesh`'s `points`.
+- `restTriVertexIndices` is derived from the `UsdGeomMesh`'s `faceVertexIndices`. An authored `restShapePoints` must then contain the same number of points as the `UsdGeomMesh`'s `points`.
+- `restNormals` is derived from the `UsdGeomBasisCurves`' `normals`.
+- `restBendAngles` and `restAdjTriPairs` have no counterpart on the simulation geometry. Where they are not authored, the rest dihedral angles are implied by `restBendAnglesDefault`, which has the fallback value `'flat'`.
+
+> **Design Note**
+>
+> Where `restBendAngles` and `restAdjTriPairs` are not authored, the rest dihedral angles are not derived from the simulation geometry as the remaining rest shape attributes are. The fallback value `'flat'` of `restBendAnglesDefault` implies rest dihedral angles of zero degrees, rather than the angles as given by the simulation geometry. The latter would follow from a fallback value of `'restShape'`, which was found to be less useful in general.
+
 ### Collision Geometries
 
 Defining colliders for a deformable body works analogously to rigid bodies. `UsdGeomPointBased` geometries in the deformable body hierarchy can be marked with the `UsdPhysicsCollisionAPI`, which elects them to participate in collision detection. Deformable body colliders are limited to any `UsdGeomPointBased` prim because they need to be able to follow the deformable body's deformation. The collider geometries are embedded into the simulation geometry and contact forces/impulses computed against the colliders can be converted to constraints against the simulation geometry in the simulator. Embedding is supported through the `UsdPhysicsDeformablePoseAPI`, see section [Geometry Embeddings](#geometry-embeddings).
@@ -368,7 +386,7 @@ Defining colliders for a deformable body works analogously to rigid bodies. `Usd
 
 Here is an example of a single geometry volume deformable body:
 
-```usda
+```python
 def TetMesh "volumeDeformable" (
     prepend apiSchemas = [
         "PhysicsDeformableBodyAPI",
@@ -384,7 +402,7 @@ def TetMesh "volumeDeformable" (
 
 And here is an example of a volume deformable body using a specialized simulation geometry:
 
-```usda
+```python
 def Xform "volumeDeformable" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -407,7 +425,7 @@ def Xform "volumeDeformable" (
 
 And here is another example for a surface deformable configured for collision detection using point samples:
 
-```usda
+```python
 def Xform "surfaceDeformable" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -443,7 +461,7 @@ Geometries that are exclusively used for graphics are not particularly tagged bu
 
 The tire example would look something like this:
 
-```usda
+```python
 def Xform "tire" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -466,7 +484,7 @@ def Xform "tire" (
 
 For surface deformables, the simulation mesh is of type `UsdGeomMesh`, but can still be discretized differently than the graphics mesh:
 
-```usda
+```python
 def Xform "surfaceDeformable" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -488,7 +506,7 @@ def Xform "surfaceDeformable" (
 
 For curve deformables, a similar pattern is followed:
 
-```usda
+```python
 def Xform "curvesDeformable" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -512,7 +530,7 @@ It is common in the case of hair/fur simulation to simulate only a subset of cur
 
 Pre-existing graphical assets often consist of multiple graphics meshes, for example, to facilitate easy assignment of graphics materials, and may be organized hierarchically. For example:
 
-```usda
+```python
 def Xform "rubberChickenToy" ()
 {
     def Mesh "body" () { ... }
@@ -531,7 +549,7 @@ def Xform "rubberChickenToy" ()
 
 Marking such an asset for rigid body simulation would be relatively easy as follows: apply `UsdPhysicsRigidBodyAPI` to rubberChickenToy, apply `UsdPhysicsCollisionAPI` and `UsdPhysicsMeshCollisionAPI` to all meshes in the subtree. For deformable body simulation, a tool is assumed to apply the `UsdPhysicsDeformableBodyAPI` to the root, then generate a suitable simulation `UsdGeomTetMesh` with `UsdPhysicsVolumeDeformableSimAPI` that represents the entire volume occupied by the body, eyeballs, right and left legs of the chicken toy. If, for example, the generated simulation mesh is suitable for collision detection as well, it can be re-used as a collider by applying a `UsdPhysicsCollisionAPI`:
 
-```usda
+```python
 def Xform "rubberChickenToy" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -577,13 +595,14 @@ This example illustrates only one possible embedding approach. In practice, nume
 
 To facilitate the specification of auxiliary poses for deformable geometries, the `UsdPhysicsDeformablePoseAPI` is introduced. This API can be applied to any `UsdGeomPointBased` prim.
 
-```usda
+```python
 class "PhysicsDeformablePoseAPI"
 (
     customData = {
         token apiSchemaType = "multipleApply"
         token propertyNamespacePrefix = "physics:deformablePose"
     }
+
     inherits = </APISchemaBase>
 )
 {
@@ -596,11 +615,11 @@ A *multiple-apply* API schema allows multiple distinct poses to be specified for
 
 A *bind pose* for a `UsdGeomPointBased` geometry can be specified by applying the `UsdPhysicsDeformablePoseAPI` and adding the `'bindPose'` token to its `purposes` attribute as well as storing the points representing the bind pose in the `points` attribute.
 
-If no *bind pose* has been specified for a `UsdGeomPointBased` geometry in the deformable subtree, the simulator is assumed to interpret the *authored default value* of the `points` attribute as the *bind pose*.
+If no *bind pose* has been specified for a `UsdGeomPointBased` geometry in the deformable subtree, the simulator is assumed to interpret the value authored for the `points` attribute at the *default time code* as the *bind pose*. Such a value must then be authored.
 
 The tire example from above is extended here with a custom `UsdPhysicsDeformablePoseAPI` that defines a `bindPose` purpose:
 
-```usda
+```python
 def Xform "tire" (
     prepend apiSchemas = ["PhysicsDeformableBodyAPI"]
 )
@@ -664,7 +683,7 @@ Deformable material densities are superseded by values specified through `UsdPhy
 
 Example showing how to use a `UsdGeomSubset` prim in the previous rubber chicken toy setup to specify multi-material behavior.
 
-```usda
+```python
 def Material "softMat" (
     prepend apiSchemas = [ "PhysicsVolumeDeformableMaterialAPI" ]
 ) { ... }
@@ -794,7 +813,7 @@ Attachments between two deformable bodies or a deformable body and a `UsdGeomXfo
 
 `UsdPhysicsAttachment` is a class representing a set of attachments between two sources (which may refer to the same prim in case of self-attachment):
 
-```usda
+```python
 class PhysicsAttachment "PhysicsAttachment"
 (
     inherits = </Imageable>
@@ -881,7 +900,7 @@ The filtering always takes place at the level of the constituent elements of the
 
 Not supported is filtering based on tetrahedral elements. It is assumed filtering collisions at the tetrahedral mesh surface is sufficient.
 
-```usda
+```python
 class PhysicsElementCollisionFilter "PhysicsElementCollisionFilter"
 (
     inherits = </Imageable>
@@ -911,7 +930,7 @@ Each pair of groups defines the elements of both colliders that should not colli
 
 **Two groups each:**
 
-```usda
+```python
 groupElemCounts0 = [2, 1], groupElemIndices0 = [3, 4, 6]
 groupElemCounts1 = [2, 3], groupElemIndices1 = [9, 7, 2, 5, 6]
 ```
@@ -922,7 +941,7 @@ element 6 of src0 is filtered against element 2, 5 and 6 of src1
 
 **Pairwise:**
 
-```usda
+```python
 groupElemCounts0 = [1, 1], groupElemIndices0 = [3, 4]
 groupElemCounts1 = [1, 1], groupElemIndices1 = [9, 7]
 ```
@@ -933,7 +952,7 @@ element 4 of src0 is filtered against element 7 of src1
 
 **Mixed:**
 
-```usda
+```python
 groupElemCounts0 = [3, 2], groupElemIndices0 = [6, 7, 8, 15, 16]
 groupElemCounts1 = [0, 1], groupElemIndices1 = [33]
 ```
@@ -944,7 +963,7 @@ element 15 and 16 of src0 are filtered against element 33 of src1
 
 **One group against all:**
 
-```usda
+```python
 groupElemCounts0 = [3], groupElemIndices0 = [3, 4, 6]
 groupElemCounts1 = [0], groupElemIndices1 = []
 ```

--- a/proposals/physics_deformables/wp_deformable_physics.md
+++ b/proposals/physics_deformables/wp_deformable_physics.md
@@ -116,27 +116,21 @@ The USD schema defines fallback values for unauthored attributes. The USD Physic
 - `youngsModulus` has units of mass/(distance·seconds·seconds), equivalent to force/area, a range of [0, inf), and a fallback value of -inf. Young's modulus is then assumed to be 10⁶ Pa (kg/(m·s²)), approximately the stiffness of silicone rubber, converted into the stage's units.
 - `poissonsRatio` is unitless, has a range of (-1.0, 0.5], and a fallback value of 0.3.
 
-`UsdPhysicsSurfaceDeformableMaterialAPI` introduces properties for thin shells, including thickness, the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and three distinct stiffness parameters, one for each deformation mode - stretch, shear, and bend:
+`UsdPhysicsSurfaceDeformableMaterialAPI` introduces properties for thin shells, including the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and three distinct stiffness parameters, one for each deformation mode - stretch, shear, and bend:
 
-- `surfaceThickness` has units of distance, a range of (0, inf), and a fallback value of -inf. The thickness is then assumed to be 10⁻³ m, converted into the stage's units.
 - `youngsModulus` and `poissonsRatio` are as described above for the volume material.
 - `surfaceStretchStiffness` and `surfaceShearStiffness` have units of mass/(seconds·seconds), equivalent to force/distance, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 - `surfaceBendStiffness` has units of mass·distance·distance/(seconds·seconds), equivalent to force·distance, a range of [0, inf), and a fallback value of -inf. The stiffness is then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 
-`UsdPhysicsCurvesDeformableMaterialAPI` introduces properties for deformable curves, including thickness, the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and four distinct stiffness parameters, one for each deformation mode - stretch, shear, bend, and twist:
+`UsdPhysicsCurvesDeformableMaterialAPI` introduces properties for deformable curves, including the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and four distinct stiffness parameters, one for each deformation mode - stretch, shear, bend, and twist:
 
-- `curvesThickness` has units of distance, a range of (0, inf), and a fallback value of -inf. The thickness is then assumed to be 10⁻³ m, converted into the stage's units.
 - `youngsModulus` and `poissonsRatio` are as described above for the volume material.
 - `curvesStretchStiffness` and `curvesShearStiffness` have units of mass·distance/(seconds·seconds), equivalent to force, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 - `curvesBendStiffness` and `curvesTwistStiffness` have units of mass·distance·distance·distance/(seconds·seconds), equivalent to force·area, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 
-`UsdGeomBasisCurves`, the geometry type used for curve deformables, defines a `widths` attribute for rendering. The material's `curvesThickness` parameter is intentionally separate, as the physical thickness that governs simulation behavior often needs to differ from the graphical width.
-
-The `surfaceThickness` and `curvesThickness` attributes are needed to compute masses based on material density, in addition to their role in the volumetric stiffness fallback.
-
 It is permitted to apply multiple physics material APIs to a single material, so that one material can be used on rigid objects and on deformable objects of any type. For example, a general-purpose physics material instance, "rubberMaterial", can be defined by applying `UsdPhysicsMaterialAPI`, `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI` in combination.
 
-Because these APIs are applied to the same primitive, their attributes share a single property namespace. A material's dynamic friction is therefore necessarily the same for its rigid and its deformable use. Such sharing is appropriate for the properties whose meaning is independent of the deformable type: friction, density, `youngsModulus` and `poissonsRatio`. Where sharing is too restrictive, separate materials (for example a "rigidRubber" and a "deformableRubber") can be authored instead. Properties whose meaning depends on the deformable type are prefixed accordingly so that they stay distinct and their units remain unambiguous. Thickness is `surfaceThickness` for surfaces and `curvesThickness` for curves, and likewise for the per-mode stiffnesses.
+Because these APIs are applied to the same primitive, their attributes share a single property namespace. A material's dynamic friction is therefore necessarily the same for its rigid and its deformable use. Such sharing is appropriate for the properties whose meaning is independent of the deformable type: friction, density, `youngsModulus` and `poissonsRatio`. Where sharing is too restrictive, separate materials (for example a "rigidRubber" and a "deformableRubber") can be authored instead. Properties whose meaning depends on the deformable type are prefixed accordingly so that they stay distinct and their units remain unambiguous. For example, stretch stiffness is `surfaceStretchStiffness` with units of force/distance for surfaces and `curvesStretchStiffness` with units of force for curves, and likewise for the other deformation modes.
 
 For details on deformable material assignment, see [Assigning Materials](#assigning-materials).
 
@@ -157,7 +151,6 @@ class "PhysicsSurfaceDeformableMaterialAPI"
     prepend apiSchemas = ["PhysicsMaterialAPI"]
 )
 {
-    float physics:surfaceThickness = -inf ()
     float physics:youngsModulus = -inf ()
     float physics:poissonsRatio = 0.3 ()
     float physics:surfaceStretchStiffness = -inf ()
@@ -171,7 +164,6 @@ class "PhysicsCurvesDeformableMaterialAPI"
     prepend apiSchemas = ["PhysicsMaterialAPI"]
 )
 {
-    float physics:curvesThickness = -inf ()
     float physics:youngsModulus = -inf ()
     float physics:poissonsRatio = 0.3 ()
     float physics:curvesStretchStiffness = -inf ()
@@ -183,9 +175,9 @@ class "PhysicsCurvesDeformableMaterialAPI"
 
 #### Volumetric Fallback for Structural Stiffnesses
 
-Each stiffness may be authored directly, or left unauthored and derived from `youngsModulus` ($E$), `poissonsRatio` ($\nu$) and thickness ($h$) using the isotropic relations below. $E$, $\nu$ and $h$ are themselves either authored or assumed (10⁶ Pa for $E$, 10⁻³ m for $h$, 0.3 for $\nu$), so a derived stiffness always has a well-defined value.
+Each stiffness may be authored directly, or left unauthored and derived from `youngsModulus` ($E$), `poissonsRatio` ($\nu$) and the thickness ($h$) specified on the simulation geometry, see [Masses and Thicknesses](#masses-and-thicknesses), using the isotropic relations below. $E$, $\nu$ and $h$ are themselves either authored or assumed (10⁶ Pa for $E$, 10⁻³ m for $h$, 0.3 for $\nu$), so a derived stiffness always has a well-defined value.
 
-In this derivation, each stiffness is a per-deformation-mode material modulus times a geometric factor set by the shell thickness or rod cross-section. Because the geometric factor depends on thickness, the derived stiffness scales with it, whereas a directly authored stiffness does not.
+In this derivation, each stiffness is a per-deformation-mode material modulus times a geometric factor set by the shell thickness or rod cross-section diameter. Because the geometric factor depends on thickness, the derived stiffness scales with it, whereas a directly authored stiffness does not.
 
 For surface materials, the moduli follow the classical thin-plate model, valid when the thickness is small relative to the in-plane dimensions (Timoshenko & Woinowsky-Krieger, *Theory of Plates and Shells*, 1959). The plane-stress assumption of the model contributes the additional $1 / (1 - \nu^2)$ factor to the stretch and bend entries.
 
@@ -195,7 +187,7 @@ For surface materials, the moduli follow the classical thin-plate model, valid w
 | shear   | $G$ | $h$ | $G \cdot h$ |
 | bend    | $E / (12(1 - \nu^2))$ | $h^3$ | $E \cdot h^3 / (12(1 - \nu^2))$ |
 
-where $E$ is `youngsModulus`, $\nu$ is `poissonsRatio`, $h$ is `surfaceThickness`, and $G = E / (2(1 + \nu))$ is the shear modulus.
+where $E$ is `youngsModulus`, $\nu$ is `poissonsRatio`, and $G = E / (2(1 + \nu))$ is the shear modulus. The thickness $h$ is sampled on the face for stretch and shear, and on the edge between two faces for bend.
 
 For curve materials, the moduli follow classical beam theory for a solid circular cross-section of radius $h/2$ (Timoshenko, *Strength of Materials*, Part I, 3rd ed., 1955). The `curvesShearStiffness` attribute describes transverse shear, the cross-section tilting away from the tangent, unlike the in-plane shear described by `surfaceShearStiffness`. Non-circular cross-sections are not captured and require authoring the affected stiffnesses directly.
 
@@ -206,7 +198,7 @@ For curve materials, the moduli follow classical beam theory for a solid circula
 | bend    | $E$ | $I$ | $E \cdot I$ |
 | twist   | $G$ | $J$ | $G \cdot J$ |
 
-where $h$ is `curvesThickness`, $A = \pi h^2 / 4$ is the cross-section area (stretch and shear), $I = \pi h^4 / 64$ is the second moment of area (bend), $J = \pi h^4 / 32$ is the polar moment of area (twist), and $k \approx 0.9$ is a shear correction factor for a circular section.
+where $A = \pi h^2 / 4$ is the cross-section area (stretch and shear), $I = \pi h^4 / 64$ is the second moment of area (bend), $J = \pi h^4 / 32$ is the polar moment of area (twist), and $k \approx 0.9$ is a shear correction factor for a circular section. The thickness $h$ is sampled on the segment for stretch and shear, and on the vertex between two segments for bend and twist.
 
 > **Design Note**
 >
@@ -274,9 +266,9 @@ For volume deformables, a tetrahedral mesh is used to encode the simulation stat
 
 For curve deformables, individual segments need to be addressable. The number of segments per curve is computed from the `UsdGeomBasisCurves` topology via its `ComputeSegmentCounts` function, which uses the `curveVertexCounts` and `wrap` attributes. Specifically, segments are enumerated flatly across the primitive in curve order: for a curve whose vertices are v[*a*], …, v[*b*], the segments are (v[*i*], v[*i*+1]) for *i*=*a*,...,*b*-1, plus a closing segment (v[*b*], v[*a*]) when the curve is periodic (`wrap` set to `'periodic'`).
 
-The simulation APIs provide a `masses` attribute for specifying a per-point mass on the simulation geometry. When the `masses` attribute is specified, the size of the array must match the number of points defined in the simulation geometry's `points` attribute. These per-point mass definitions take precedence over any mass or density parameters specified by `UsdPhysicsDeformableBodyAPI` or `UsdPhysicsMaterialAPI`.
+The simulation APIs provide a `masses` attribute, and for surfaces and curves additionally a `thicknesses` attribute, both detailed in [Masses and Thicknesses](#masses-and-thicknesses).
 
-The rest shape of a deformable body may be represented by attributes of the type-specific simulation API, detailed in the following subsection.
+The rest shape of a deformable body may be represented by attributes of the type-specific simulation API, detailed in [Rest Shape Attributes](#rest-shape-attributes).
 
 ```python
 class "PhysicsVolumeDeformableSimAPI"
@@ -284,9 +276,12 @@ class "PhysicsVolumeDeformableSimAPI"
     inherits = </APISchemaBase>
 )
 {
+    # elementType is constant, tetrahedron, or point
+    float[] physics:masses ()
+    uniform token physics:masses:elementType = "" ()
+
     point3f[] physics:restShapePoints ()
     int4[] physics:restTetVertexIndices ()
-    float[] physics:masses ()
 }
 
 class "PhysicsSurfaceDeformableSimAPI"
@@ -294,12 +289,17 @@ class "PhysicsSurfaceDeformableSimAPI"
     inherits = </APISchemaBase>
 )
 {
+    # each elementType is constant, face, or point
+    float[] physics:masses ()
+    uniform token physics:masses:elementType = "" ()
+    float[] physics:thicknesses ()
+    uniform token physics:thicknesses:elementType = "" ()
+
     point3f[] physics:restShapePoints ()
     int3[] physics:restTriVertexIndices ()
     uniform token physics:restBendAnglesDefault = "flat" ()
     int2[] physics:restAdjTriPairs ()
     float[] physics:restBendAngles ()
-    float[] physics:masses ()
 }
 
 class "PhysicsCurvesDeformableSimAPI"
@@ -307,11 +307,40 @@ class "PhysicsCurvesDeformableSimAPI"
     inherits = </APISchemaBase>
 )
 {
+    # each elementType is constant, curve, segment, or point
+    float[] physics:masses ()
+    uniform token physics:masses:elementType = "" ()
+    float[] physics:thicknesses ()
+    uniform token physics:thicknesses:elementType = "" ()
+
     point3f[] physics:restShapePoints ()
     normal3f[] physics:restNormals ()
-    float[] physics:masses ()
 }
 ```
+
+#### Masses and Thicknesses
+
+Mass and thickness are specified on the simulation geometry as arrays:
+
+- `masses` has units of mass and a range of (0, inf). Where it is not authored, the masses are derived from the lower-precedence sources described in [Mass Distribution](#mass-distribution).
+- `thicknesses`, defined by the surface and curves simulation APIs, has units of distance and a range of (0, inf), and provides the thickness of a shell or the diameter of the rod cross-section. Where it is not authored, the thickness is assumed to be 10⁻³ m, converted into the stage's units.
+
+Each array is paired with an `elementType` attribute in the array's own namespace, naming the geometry features its values apply to. The size of the array must match the number of those features:
+
+- `'constant'`: the whole geometry, in an array of size one. A single thickness value represents a constant value over the whole geometry. A single mass value represents the total mass, the same quantity that can be expressed by `UsdPhysicsDeformableBodyAPI:mass`.
+- `'curve'`: the curves of a `UsdGeomBasisCurves`. Each thickness value represents a constant value over its curve. Each mass value represents the total mass of its curve.
+- `'tetrahedron'`, `'face'`, `'segment'`: the elements of a `UsdGeomTetMesh`, `UsdGeomMesh` or `UsdGeomBasisCurves`.
+- `'point'`: the points of the simulation geometry's `points` attribute.
+
+Each `elementType` attribute has an empty string for its fallback value, a sentinel outside the supported element types. The empty string is valid only for an empty array, including an unauthored one.
+
+If a simulator requires an element type other than the authored one, the thickness at the desired location is obtained by averaging the adjacent samples, and masses are converted between points and elements as described in [Mass Distribution](#mass-distribution).
+
+`UsdGeomBasisCurves`, the geometry type used for curve deformables, defines a `widths` attribute for rendering. The `thicknesses` attribute is intentionally separate, as the physical thickness that governs simulation behavior often needs to differ from the graphical width.
+
+> **Design Note**
+>
+> Primvars on the simulation geometry were considered as an alternative to the arrays and their `elementType` attributes, as they are the established mechanism for values that vary over a geometry. They were dismissed mainly because no primvar interpolation addresses the segments of a linear `UsdGeomBasisCurves`, where `uniform` is per curve, and `varying` and `vertex` are both per point.
 
 ### Rest Shape Attributes
 
@@ -449,7 +478,7 @@ def Xform "surfaceDeformable" (
 The following collision-related schemas interact with deformable body colliders as follows:
 
 - Group and pair filters as defined with `UsdPhysicsCollisionGroup` and `UsdPhysicsFilteredPairsAPI` directly apply to deformable body colliders.
-- `UsdPhysicsMassAPI` as supported for rigid body colliders will be ignored. Instead, non-uniform mass distributions across the simulation geometry can be expressed directly by specifying per-point masses or by using deformable material API bindings affecting the simulation geometry, see [Assigning Materials](#assigning-materials) and [Mass Distribution](#mass-distribution) for more details.
+- `UsdPhysicsMassAPI` as supported for rigid body colliders will be ignored. Instead, non-uniform mass distributions across the simulation geometry can be expressed directly by the `masses` and `thicknesses` attributes of the simulation APIs, or by using deformable material API bindings affecting the simulation geometry, see [Assigning Materials](#assigning-materials) and [Mass Distribution](#mass-distribution) for more details.
 
 Even though geometries are explicitly tagged to participate in collision detection, the implementation is still free to choose whether to create an intermediate representation for the collision geometry or geometries it uses internally. However, such an implicit approach has the disadvantage that the per-element collision filtering covered in the section [Element Collision Filtering](#element-collision-filtering) can't be applied. The `UsdPhysicsElementCollisionFilter` relies on explicit representation for deformable collision geometries in USD.
 
@@ -669,7 +698,6 @@ Simulation geometries, tagged with a deformable simulation API, are affected by 
 - Density
 - Young's modulus
 - Poisson's ratio
-- Surface or curve thickness
 - Various stiffness parameters
 
 Collision geometries, tagged with the collision API, are affected by `'surface'` properties
@@ -679,7 +707,7 @@ Collision geometries, tagged with the collision API, are affected by `'surface'`
 
 Properties are by default propagated down the object tree to the simulation geometry and collision geometries. Additionally, materials can be bound to `UsdGeomSubset` prims of these geometries. Simulator implementations can use this feature, if they support sub-geometry element material assignments. For example, the non-uniform density of a volume deformable body may be inferred by reading the material densities of the simulation mesh's `UsdGeomSubset` prims with `'tetrahedron'` element type as described in section [Mass Distribution](#mass-distribution). `UsdPhysicsSurfaceDeformableMaterialAPI` `surfaceBendStiffness` values may be assigned to specific simulation mesh edges via a `UsdGeomSubset` using the `'edge'` element type.
 
-Deformable material densities are superseded by values specified through `UsdPhysicsDeformableBodyAPI:mass` and `density`, analogous to how rigid body material densities are superseded by `UsdPhysicsMassAPI` masses and densities. Additionally, material densities are also superseded by explicit per-point masses specified on the simulation geometry, such as `UsdPhysicsVolumeDeformableSimAPI:masses`.
+Deformable material densities are superseded by values specified through `UsdPhysicsDeformableBodyAPI:mass` and `density`, analogous to how rigid body material densities are superseded by `UsdPhysicsMassAPI` masses and densities. Additionally, material densities are also superseded by explicit masses specified on the simulation geometry, such as `UsdPhysicsVolumeDeformableSimAPI:masses`.
 
 Example showing how to use a `UsdGeomSubset` prim in the previous rubber chicken toy setup to specify multi-material behavior.
 
@@ -738,7 +766,7 @@ def Xform "rubberChickenToy" (
 
 > **Design Note**
 >
-> Material properties assume discrete values. Variations across a single deformable geometry may be realized using multiple `UsdGeomSubset` prims. However, this approach is not practical for approximating a continuous variation of properties such as density, thickness, or stiffness. A natural extension would be to allow primvars to act as multipliers on material values, so that the effective value can be expressed as `value_effective = value_material * value_primvar`. For example, a primvar named `physics:densityScale` with vertex interpolation could scale the material density across the geometry, yielding a spatially varying mass distribution. This approach would complement rather than replace material based assignment. Such a mechanism is not currently part of the UsdPhysics specification but could serve as a future extension point.
+> Material properties assume discrete values. Variations across a single deformable geometry may be realized using multiple `UsdGeomSubset` prims. However, this approach is not practical for approximating a continuous variation of properties such as density or stiffness. A natural extension would be to introduce arrays on the simulation geometry, in the manner of `masses` and `thicknesses`, acting as multipliers on material values, so that the effective value can be expressed as `value_effective = value_material * value_array`. For example, a `physics:youngsModulusScale` array could scale the material's Young's modulus across the geometry, yielding a spatially varying stiffness. This approach would complement rather than replace material based assignment. Such a mechanism is not currently part of the UsdPhysics specification but could serve as a future extension point.
 
 > **Design Note**
 >
@@ -746,45 +774,69 @@ def Xform "rubberChickenToy" (
 
 ### Mass Distribution
 
-For rigid bodies the specification of the mass distribution centers around `UsdPhysicsMaterialAPI`, `UsdPhysicsMassAPI` and geometries with `UsdPhysicsCollisionAPI`. The latter are used to define how mass is distributed. However, simulators may differ in how collision volumes are defined through `UsdPhysicsMeshCollisionAPI:approximation`, which also affects the effective mass distribution. For deformable bodies, mass is fundamentally a per-point quantity on the simulation geometry, which provides an opportunity to specify the mass distribution more definitively.
+For rigid bodies the specification of the mass distribution centers around `UsdPhysicsMaterialAPI`, `UsdPhysicsMassAPI` and geometries with `UsdPhysicsCollisionAPI`. The latter are used to define how mass is distributed. However, simulators may differ in how collision volumes are defined through `UsdPhysicsMeshCollisionAPI:approximation`, which also affects the effective mass distribution. For deformable bodies, mass is distributed over the elements of the simulation geometry, which provides an opportunity to specify the mass distribution more definitively.
 
-The mass distribution can be authored at several levels, listed below in order of decreasing precedence. When an attribute is not authored, per-point masses are implicitly derived from a lower-precedence source using the formulas below.
+The element volume $V_e$ is evaluated based on the rest shape, $T$ is the number of points of an element, and $d$ is the element thickness given by `thicknesses`:
 
-1. Per-point masses may be explicitly specified by the `masses` attribute given by `UsdPhysicsVolumeDeformableSimAPI`, `UsdPhysicsSurfaceDeformableSimAPI`, or `UsdPhysicsCurvesDeformableSimAPI`.
+- For volume deformables, $V_e$ is the volume of a single tetrahedron, while $T$ is 4.
+- For surface deformables, $V_e = A_e d$, while $A_e$ is the area of a single triangle and $T$ is 3.
+- For curve deformables, $V_e = L_e \frac{\pi d^2}{4}$, while $L_e$ is the length of a single segment and $T$ is 2.
 
-2. `UsdPhysicsDeformableBodyAPI:mass`, the total mass of the body. Per-point masses are derived as
-
-   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = m_{tot}\, \frac{V_p}{V_{tot}}$
-
-   where $m_{tot}$ is the authored body mass, $V_p$ is the volume occupied by the point $p$ (defined below), and $V_{tot}$ is the total volume of the body, summed over all elements.
-
-3. `UsdPhysicsDeformableBodyAPI:density`. Per-point masses are derived as
-
-   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = \rho V_p$
-
-   where $\rho$ is the authored body density and $V_p$ is the volume occupied by the point $p$ (defined below).
-
-4. `UsdPhysicsMaterialAPI:density`, applied according to the binding rules described in [Assigning Materials](#assigning-materials). If a single density applies to the whole simulation geometry, this is equivalent to case 3. If different densities apply to subsets of elements via `UsdGeomSubset`, $V_p$ decomposes into contributions $V_p^{(i)}$ from elements bound to each material $i$, and the per-point mass is
-
-   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = \sum_i \rho_i V_p^{(i)}$
-
-   where $\rho_i$ is the density of material $i$. It therefore makes sense to restrict the `elementType` of the `UsdGeomSubset` for material mass properties assignment to:
-
-   - `'tetrahedron'`: for volume material `density`
-   - `'face'`: for surface material `density` and `surfaceThickness`
-   - `'segment'`: for curve material `density` and `curvesThickness`
-
-5. A density of 1000 kg/m³ (approximately the density of water) when no density is specified by any of the above, as defined by the USD Physics rigid bodies schema. The value is converted into the stage's units, and the per-point masses are then derived as in case 3.
-
-The per-point volume $V_p$ is computed from the simulation geometry topology and the rest shape element volumes:
+The per-point volume $V_p$ is computed from the simulation geometry topology and the element volumes:
 
 $$V_p = \sum_{e\, \in\, \tau(p)} \frac{V_e}{T}$$
 
-where $\tau(p)$ is the set of elements adjacent to $p$ according to the simulation geometry connectivity, $V_e$ is the volume of elements $e$ evaluated based on the rest shape, and $T$ weights the contribution of a single element on its adjacent points:
+where $\tau(p)$ is the set of elements adjacent to $p$ according to the simulation geometry connectivity.
 
-- For volume deformables, $V_e$ is the volume of a single tetrahedron, while $T$ is 4.
-- For surface deformables, $V_e = A_e d$, while $A_e$ is the area of a single triangle, $d$ is `surfaceThickness`, and $T$ is 3.
-- For curve deformables, $V_e = L_e \frac{\pi d^2}{4}$, while $L_e$ is the length of a single segment, $d$ is `curvesThickness`, and $T$ is 2.
+The mass distribution can be authored at several levels, listed below in order of decreasing precedence. Each level describes the mass of an element. When an attribute is not authored, element masses are implicitly derived from a lower-precedence source using the formulas below.
+
+1. Masses may be explicitly specified by the `masses` attribute given by `UsdPhysicsVolumeDeformableSimAPI`, `UsdPhysicsSurfaceDeformableSimAPI`, or `UsdPhysicsCurvesDeformableSimAPI`, see [Masses and Thicknesses](#masses-and-thicknesses). With elementType `'tetrahedron'`, `'face'`, or `'segment'`, the element mass $m_e$ is authored directly.
+
+   With `'constant'`,
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = m_{tot}\, \frac{V_e}{V_{tot}}$
+
+   where $m_{tot}$ is the authored mass of the whole geometry and $V_{tot}$ its volume.
+
+   With `'curve'`,
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = m_{curve}\, \frac{V_e}{V_{curve}}$
+
+   where $m_{curve}$ is the authored mass of the curve containing $e$ and $V_{curve}$ its volume.
+
+   With `'point'`,
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = \frac{V_e}{T} \sum_{p\, \in\, e} \frac{m_p}{V_p}$
+
+   the element volume times the mean density of its points.
+
+2. `UsdPhysicsDeformableBodyAPI:mass`, the total mass of the body. Element masses are derived as
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = m_{tot}\, \frac{V_e}{V_{tot}}$
+
+   where $m_{tot}$ is the authored body mass and $V_{tot}$ the volume of the whole body.
+
+3. `UsdPhysicsDeformableBodyAPI:density`. Element masses are derived as
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = \rho V_e$
+
+   where $\rho$ is the authored body density.
+
+4. `UsdPhysicsMaterialAPI:density`, applied according to the binding rules described in [Assigning Materials](#assigning-materials). If a single density applies to the whole simulation geometry, this is equivalent to case 3. If different densities apply to subsets of elements via `UsdGeomSubset`, each element takes the density of the material bound to it:
+
+   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_e = \rho_e V_e$
+
+   where $\rho_e$ is the density of the material bound to element $e$. It therefore makes sense to restrict the `elementType` of the `UsdGeomSubset` for material mass properties assignment to:
+
+   - `'tetrahedron'`: for volume material `density`
+   - `'face'`: for surface material `density`
+   - `'segment'`: for curve material `density`
+
+5. A density of 1000 kg/m³ (approximately the density of water) when no density is specified by any of the above, as defined by the USD Physics rigid bodies schema. The value is converted into the stage's units, and the element masses are then derived as in case 3.
+
+Simulators commonly integrate the equation of motion at the points. The mass of each element is then split equally over its points, conserving the total mass:
+
+$$m_p = \sum_{e\, \in\, \tau(p)} \frac{m_e}{T}$$
 
 The USD Physics rigid bodies schema pairs its density default with a default total mass of 1.0 in the stage's mass units, for the case in which there are no collision volumes to derive a mass from. No corresponding case arises for deformable bodies: a deformable body always has a simulation geometry, so element volumes are always available and the mass distribution is always derivable.
 

--- a/proposals/physics_deformables/wp_deformable_physics.md
+++ b/proposals/physics_deformables/wp_deformable_physics.md
@@ -108,28 +108,34 @@ class "PhysicsMaterialAPI"
 
 Three new material APIs are introduced: `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI`, each extending `UsdPhysicsMaterialAPI` with properties to specify the deformable behavior.
 
-The USD schema defines fallback values for unauthored attributes. Attributes with physical units depending on distance, time or mass use special fallback values called *sentinel values*, indicating that a suitable default is chosen by the simulator (hereafter referred to as a *simulator default*). This is necessary because appropriate values for such attributes depend on the stage's unit settings.
+The USD schema defines fallback values for unauthored attributes. The USD Physics schemas make use of *sentinel values*, fallback values that lie outside an attribute's defined range. For each attribute with a sentinel fallback, the schema documents how it is to be interpreted.
 
 `UsdPhysicsVolumeDeformableMaterialAPI` introduces the important engineering concepts of Young's modulus and Poisson's ratio as attributes:
 
-- `youngsModulus` has units of mass/(distance·seconds·seconds), equivalent to force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
-- `poissonsRatio` is unitless, has a range of [-1.0, 0.5], and a fallback value of 0.3.
+- `youngsModulus` has units of mass/(distance·seconds·seconds), equivalent to force/area, a range of [0, inf), and a fallback value of -inf. Young's modulus is then assumed to be 10⁶ Pa (kg/(m·s²)), approximately the stiffness of silicone rubber, converted into the stage's units.
+- `poissonsRatio` is unitless, has a range of (-1.0, 0.5], and a fallback value of 0.3.
 
-`UsdPhysicsSurfaceDeformableMaterialAPI` introduces properties for thin shells, including thickness and three distinct stiffness parameters for the deformation modes - stretch, shear, and bend:
+`UsdPhysicsSurfaceDeformableMaterialAPI` introduces properties for thin shells, including thickness, the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and three distinct stiffness parameters, one for each deformation mode - stretch, shear, and bend:
 
-- `thickness` has units of distance, a range of (0, inf), and a fallback value of -inf (simulator default).
-- `stretchStiffness`, `shearStiffness`, `bendStiffness` have units of force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
+- `surfaceThickness` has units of distance, a range of (0, inf), and a fallback value of -inf. The thickness is then assumed to be 10⁻³ m, converted into the stage's units.
+- `youngsModulus` and `poissonsRatio` are as described above for the volume material.
+- `surfaceStretchStiffness` and `surfaceShearStiffness` have units of mass/(seconds·seconds), equivalent to force/distance, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
+- `surfaceBendStiffness` has units of mass·distance·distance/(seconds·seconds), equivalent to force·distance, a range of [0, inf), and a fallback value of -inf. The stiffness is then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 
-`UsdPhysicsCurvesDeformableMaterialAPI` introduces properties for deformable curves, including thickness and four distinct stiffness parameters for the deformation modes - stretch, shear, bend, and twist:
+`UsdPhysicsCurvesDeformableMaterialAPI` introduces properties for deformable curves, including thickness, the isotropic material parameters Young's modulus and Poisson's ratio serving as a fallback, and four distinct stiffness parameters, one for each deformation mode - stretch, shear, bend, and twist:
 
-- `thickness`, `stretchStiffness`, `shearStiffness`, `bendStiffness` as covered above.
-- `twistStiffness` has units of force/area, a range of [0, inf), and a fallback value of -inf (simulator default).
+- `curvesThickness` has units of distance, a range of (0, inf), and a fallback value of -inf. The thickness is then assumed to be 10⁻³ m, converted into the stage's units.
+- `youngsModulus` and `poissonsRatio` are as described above for the volume material.
+- `curvesStretchStiffness` and `curvesShearStiffness` have units of mass·distance/(seconds·seconds), equivalent to force, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
+- `curvesBendStiffness` and `curvesTwistStiffness` have units of mass·distance·distance·distance/(seconds·seconds), equivalent to force·area, a range of [0, inf), and a fallback value of -inf. The stiffnesses are then derived as described in [Volumetric Fallback for Structural Stiffnesses](#volumetric-fallback-for-structural-stiffnesses).
 
-`UsdGeomBasisCurves`, the geometry type used for curve deformables, defines a `widths` attribute for rendering. The material's `thickness` parameter is intentionally separate, as the physical thickness that governs simulation behavior often needs to differ from the graphical width.
+`UsdGeomBasisCurves`, the geometry type used for curve deformables, defines a `widths` attribute for rendering. The material's `curvesThickness` parameter is intentionally separate, as the physical thickness that governs simulation behavior often needs to differ from the graphical width.
 
-The `thickness` attribute for surface and curve deformables is needed to compute masses based on material density.
+The `surfaceThickness` and `curvesThickness` attributes are needed to compute masses based on material density, in addition to their role in the volumetric stiffness fallback.
 
-It is permitted to apply multiple physics material APIs to a single material. This makes it possible to use the material on both rigid objects and various types of deformable objects. For example, a general-purpose physics material instance, "rubberMaterial", can be defined by applying `UsdPhysicsMaterialAPI`, `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI` in combination. This means that e.g. the dynamic friction parameter has to be the same for rigid and deformable use cases. If this is a problem, the workaround is to create e.g. separate rigidRubber and deformableRubber materials.
+It is permitted to apply multiple physics material APIs to a single material, so that one material can be used on rigid objects and on deformable objects of any type. For example, a general-purpose physics material instance, "rubberMaterial", can be defined by applying `UsdPhysicsMaterialAPI`, `UsdPhysicsVolumeDeformableMaterialAPI`, `UsdPhysicsSurfaceDeformableMaterialAPI` and `UsdPhysicsCurvesDeformableMaterialAPI` in combination.
+
+Because these APIs are applied to the same primitive, their attributes share a single property namespace. A material's dynamic friction is therefore necessarily the same for its rigid and its deformable use. Such sharing is appropriate for the properties whose meaning is independent of the deformable type: friction, density, `youngsModulus` and `poissonsRatio`. Where sharing is too restrictive, separate materials (for example a "rigidRubber" and a "deformableRubber") can be authored instead. Properties whose meaning depends on the deformable type are prefixed accordingly so that they stay distinct and their units remain unambiguous. Thickness is `surfaceThickness` for surfaces and `curvesThickness` for curves, and likewise for the per-mode stiffnesses.
 
 For details on deformable material assignment, see [Assigning Materials](#assigning-materials).
 
@@ -150,10 +156,12 @@ class "PhysicsSurfaceDeformableMaterialAPI"
     prepend apiSchemas = ["PhysicsMaterialAPI"]
 )
 {
-    float physics:thickness = -inf ()
-    float physics:stretchStiffness = -inf ()
-    float physics:shearStiffness = -inf ()
-    float physics:bendStiffness = -inf ()
+    float physics:surfaceThickness = -inf ()
+    float physics:youngsModulus = -inf ()
+    float physics:poissonsRatio = 0.3 ()
+    float physics:surfaceStretchStiffness = -inf ()
+    float physics:surfaceShearStiffness = -inf ()
+    float physics:surfaceBendStiffness = -inf ()
 }
 
 class "PhysicsCurvesDeformableMaterialAPI"
@@ -162,13 +170,50 @@ class "PhysicsCurvesDeformableMaterialAPI"
     prepend apiSchemas = ["PhysicsMaterialAPI"]
 )
 {
-    float physics:thickness = -inf ()
-    float physics:stretchStiffness = -inf ()
-    float physics:shearStiffness = -inf ()
-    float physics:bendStiffness = -inf ()
-    float physics:twistStiffness = -inf ()
+    float physics:curvesThickness = -inf ()
+    float physics:youngsModulus = -inf ()
+    float physics:poissonsRatio = 0.3 ()
+    float physics:curvesStretchStiffness = -inf ()
+    float physics:curvesShearStiffness = -inf ()
+    float physics:curvesBendStiffness = -inf ()
+    float physics:curvesTwistStiffness = -inf ()
 }
 ```
+
+#### Volumetric Fallback for Structural Stiffnesses
+
+Each stiffness may be authored directly, or left unauthored and derived from `youngsModulus` ($E$), `poissonsRatio` ($\nu$) and thickness ($h$) using the isotropic relations below. $E$, $\nu$ and $h$ are themselves either authored or assumed (10⁶ Pa for $E$, 10⁻³ m for $h$, 0.3 for $\nu$), so a derived stiffness always has a well-defined value.
+
+In this derivation, each stiffness is a per-deformation-mode material modulus times a geometric factor set by the shell thickness or rod cross-section. Because the geometric factor depends on thickness, the derived stiffness scales with it, whereas a directly authored stiffness does not.
+
+For surface materials, the moduli follow the classical thin-plate model, valid when the thickness is small relative to the in-plane dimensions (Timoshenko & Woinowsky-Krieger, *Theory of Plates and Shells*, 1959). The plane-stress assumption of the model contributes the additional $1 / (1 - \nu^2)$ factor to the stretch and bend entries.
+
+| Mode | Material modulus | Geometric factor | Structural stiffness |
+|------|------------------|------------------|----------------------|
+| stretch | $E / (1 - \nu^2)$ | $h$ | $E \cdot h / (1 - \nu^2)$ |
+| shear   | $G$ | $h$ | $G \cdot h$ |
+| bend    | $E / (12(1 - \nu^2))$ | $h^3$ | $E \cdot h^3 / (12(1 - \nu^2))$ |
+
+where $E$ is `youngsModulus`, $\nu$ is `poissonsRatio`, $h$ is `surfaceThickness`, and $G = E / (2(1 + \nu))$ is the shear modulus.
+
+For curve materials, the moduli follow classical beam theory for a solid circular cross-section of radius $h/2$ (Timoshenko, *Strength of Materials*, Part I, 3rd ed., 1955). The `curvesShearStiffness` attribute describes transverse shear, the cross-section tilting away from the tangent, unlike the in-plane shear described by `surfaceShearStiffness`. Non-circular cross-sections are not captured and require authoring the affected stiffnesses directly.
+
+| Mode | Material modulus | Geometric factor | Structural stiffness |
+|------|------------------|------------------|----------------------|
+| stretch | $E$ | $A$ | $E \cdot A$ |
+| shear   | $G$ | $A$ ($\times k$) | $k \cdot G \cdot A$ |
+| bend    | $E$ | $I$ | $E \cdot I$ |
+| twist   | $G$ | $J$ | $G \cdot J$ |
+
+where $h$ is `curvesThickness`, $A = \pi h^2 / 4$ is the cross-section area (stretch and shear), $I = \pi h^4 / 64$ is the second moment of area (bend), $J = \pi h^4 / 32$ is the polar moment of area (twist), and $k \approx 0.9$ is a shear correction factor for a circular section.
+
+> **Design Note**
+>
+> The surface and curve stiffnesses may be authored directly, or left unauthored and derived from Young's modulus and Poisson's ratio. Two considerations motivate this volumetric fallback. Young's modulus and Poisson's ratio are commonly tabulated for isotropic materials, whereas the per-deformation-mode stiffnesses may be less readily available. Furthermore, the derivation provides a way to specify the material so that the resulting stiffnesses scale with the authored thickness.
+
+> **Design Note**
+>
+> The stretch, shear, bend and twist parameters are expressed as structural stiffnesses — carrying the units that follow from the stored deformation energy (force/distance and force·distance for surfaces; force and force·area for curves) — rather than as thickness-independent moduli in units of force/area. Exposing them as moduli was considered. Structural stiffnesses were slightly favored, for a few reasons. The volumetric fallback already provides a modulus-based path with thickness scaling for authors who prefer to work from Young's modulus and Poisson's ratio. Physically measuring a concrete object also directly yields its structural stiffnesses. And they are, in general, the quantities a simulator is configured with.
 
 ### Deformable Bodies
 
@@ -278,7 +323,7 @@ In the case of `UsdPhysicsVolumeDeformableSimAPI`, which is intended for tetmesh
 
 This capability is more important in the case of `UsdPhysicsSurfaceDeformableSimAPI`, which is meant to be applied to surface meshes to represent cloth and shells. In modeling cloth, it is very common to define the planar rest shape of sections of the 3D mesh in a disjoint fashion in a 2D material "panel space." The `restShapePoints` attribute of `UsdPhysicsSurfaceDeformableSimAPI` has 3D points, but disjoint sets (w.r.t `restTriVertexIndices`) of these points can be coplanar to support planar rest shape descriptions from panel-based creation tools. Furthermore, this representation allows the description of the planar rest shape that should be compatible with models for 3D shells. As with the volume case, `restTriVertexIndices` may be left empty when the the rest connectivity matches the surface mesh's connectivity exactly, in which case the surface mesh's `faceVertexIndices` is used in its place and `restShapePoints` must contain the same number of points as the surface mesh's `points`.
 
-Thin shells (e.g. cloth) based on triangular meshes also require the definition of the rest dihedral angle for the interior edges of the mesh. Using the mesh of cloth pants as an example, one might want to describe a pleat along a consecutive edge run down the front of each leg. Besides increasing the `bendStiffness` for these edges, the `restBendAngles` for these edges could be set to something like 75 degrees. The assignment of `restBendAngles` is specified via `restAdjTriPairs`, pairs of adjacent triangles the dihedral bend angles refer to.
+Thin shells (e.g. cloth) based on triangular meshes also require the definition of the rest dihedral angle for the interior edges of the mesh. Using the mesh of cloth pants as an example, one might want to describe a pleat along a consecutive edge run down the front of each leg. Besides increasing the `surfaceBendStiffness` for these edges, the `restBendAngles` for these edges could be set to something like 75 degrees. The assignment of `restBendAngles` is specified via `restAdjTriPairs`, pairs of adjacent triangles the dihedral bend angles refer to.
 
 The rest dihedral bend angles that are not explicitly specified are implicitly defined in two selectable ways. The attribute `restBendAnglesDefault` can be set to either `'flat'` or `'restShape'`. The former implies rest dihedral angles of zero degrees, which is useful for simulating cloth, for example. The latter implies rest angles based on the normals of the triangles, as defined by the rest shape points. This method is useful for simulating uneven 3D shells. The fallback value for `restBendAnglesDefault` is `'flat'`.
 
@@ -613,7 +658,7 @@ Collision geometries, tagged with the collision API, are affected by `'surface'`
 - Dynamic friction
 - Static friction
 
-Properties are by default propagated down the object tree to the simulation geometry and collision geometries. Additionally, materials can be bound to `UsdGeomSubset` prims of these geometries. Simulator implementations can use this feature, if they support sub-geometry element material assignments. For example, the non-uniform density of a volume deformable body may be inferred by reading the material densities of the simulation mesh's `UsdGeomSubset` prims with `'tetrahedron'` element type as described in section [Mass Distribution](#mass-distribution). `UsdPhysicsSurfaceDeformableMaterialAPI` `bendStiffness` values may be assigned to specific simulation mesh edges via a `UsdGeomSubset` using the `'edge'` element type.
+Properties are by default propagated down the object tree to the simulation geometry and collision geometries. Additionally, materials can be bound to `UsdGeomSubset` prims of these geometries. Simulator implementations can use this feature, if they support sub-geometry element material assignments. For example, the non-uniform density of a volume deformable body may be inferred by reading the material densities of the simulation mesh's `UsdGeomSubset` prims with `'tetrahedron'` element type as described in section [Mass Distribution](#mass-distribution). `UsdPhysicsSurfaceDeformableMaterialAPI` `surfaceBendStiffness` values may be assigned to specific simulation mesh edges via a `UsdGeomSubset` using the `'edge'` element type.
 
 Deformable material densities are superseded by values specified through `UsdPhysicsDeformableBodyAPI:mass` and `density`, analogous to how rigid body material densities are superseded by `UsdPhysicsMassAPI` masses and densities. Additionally, material densities are also superseded by explicit per-point masses specified on the simulation geometry, such as `UsdPhysicsVolumeDeformableSimAPI:masses`.
 
@@ -684,7 +729,7 @@ def Xform "rubberChickenToy" (
 
 For rigid bodies the specification of the mass distribution centers around `UsdPhysicsMaterialAPI`, `UsdPhysicsMassAPI` and geometries with `UsdPhysicsCollisionAPI`. The latter are used to define how mass is distributed. However, simulators may differ in how collision volumes are defined through `UsdPhysicsMeshCollisionAPI:approximation`, which also affects the effective mass distribution. For deformable bodies, mass is fundamentally a per-point quantity on the simulation geometry, which provides an opportunity to specify the mass distribution more definitively.
 
-The mass distribution can be authored at several levels, listed below in order of decreasing precedence. When an attribute is not authored, per-point masses are implicitly derived from a lower-precedence authored attribute using the formulas below.
+The mass distribution can be authored at several levels, listed below in order of decreasing precedence. When an attribute is not authored, per-point masses are implicitly derived from a lower-precedence source using the formulas below.
 
 1. Per-point masses may be explicitly specified by the `masses` attribute given by `UsdPhysicsVolumeDeformableSimAPI`, `UsdPhysicsSurfaceDeformableSimAPI`, or `UsdPhysicsCurvesDeformableSimAPI`.
 
@@ -698,7 +743,7 @@ The mass distribution can be authored at several levels, listed below in order o
 
    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $\displaystyle m_p = \rho V_p$
 
-   where $\rho$ is the authored body density, $V_p$ is the volume occupied by the point $p$ (defined below).
+   where $\rho$ is the authored body density and $V_p$ is the volume occupied by the point $p$ (defined below).
 
 4. `UsdPhysicsMaterialAPI:density`, applied according to the binding rules described in [Assigning Materials](#assigning-materials). If a single density applies to the whole simulation geometry, this is equivalent to case 3. If different densities apply to subsets of elements via `UsdGeomSubset`, $V_p$ decomposes into contributions $V_p^{(i)}$ from elements bound to each material $i$, and the per-point mass is
 
@@ -707,8 +752,10 @@ The mass distribution can be authored at several levels, listed below in order o
    where $\rho_i$ is the density of material $i$. It therefore makes sense to restrict the `elementType` of the `UsdGeomSubset` for material mass properties assignment to:
 
    - `'tetrahedron'`: for volume material `density`
-   - `'face'`: for surface material `density` and `thickness`
-   - `'segment'`: for curve material `density` and `thickness`
+   - `'face'`: for surface material `density` and `surfaceThickness`
+   - `'segment'`: for curve material `density` and `curvesThickness`
+
+5. A density of 1000 kg/m³ (approximately the density of water) when no density is specified by any of the above, as defined by the USD Physics rigid bodies schema. The value is converted into the stage's units, and the per-point masses are then derived as in case 3.
 
 The per-point volume $V_p$ is computed from the simulation geometry topology and the rest shape element volumes:
 
@@ -717,8 +764,10 @@ $$V_p = \sum_{e\, \in\, \tau(p)} \frac{V_e}{T}$$
 where $\tau(p)$ is the set of elements adjacent to $p$ according to the simulation geometry connectivity, $V_e$ is the volume of elements $e$ evaluated based on the rest shape, and $T$ weights the contribution of a single element on its adjacent points:
 
 - For volume deformables, $V_e$ is the volume of a single tetrahedron, while $T$ is 4.
-- For surface deformables, $V_e = A_e d$, while $A_e$ is the area of a single triangle, $d$ is `UsdPhysicsSurfaceDeformableMaterialAPI:thickness`, and $T$ is 3.
-- For curve deformables, $V_e = L_e \frac{\pi d^2}{4}$, while $L_e$ is the length of a single segment, $d$ is `UsdPhysicsCurvesDeformableMaterialAPI:thickness`, and $T$ is 2.
+- For surface deformables, $V_e = A_e d$, while $A_e$ is the area of a single triangle, $d$ is `surfaceThickness`, and $T$ is 3.
+- For curve deformables, $V_e = L_e \frac{\pi d^2}{4}$, while $L_e$ is the length of a single segment, $d$ is `curvesThickness`, and $T$ is 2.
+
+The USD Physics rigid bodies schema pairs its density default with a default total mass of 1.0 in the stage's mass units, for the case in which there are no collision volumes to derive a mass from. No corresponding case arises for deformable bodies: a deformable body always has a simulation geometry, so element volumes are always available and the mass distribution is always derivable.
 
 ### Kinematic Deformables
 
@@ -774,7 +823,7 @@ class PhysicsAttachment "PhysicsAttachment"
 - `type0`, `type1`: Specify the attachment site types for the corresponding sources. They define the kind of geometry feature the attachment sites refer to. The types need to be compatible with the corresponding sources as shown in the table below. The `type1` is set to `'xform'` for attachments to a rigid coordinate frame.
 - `indices0`, `indices1`: Specify the geometry feature indices for the sites. They are interpreted according to the type attributes and typically both arrays need to have the same number of elements, one per attachment site. There is one notable exception. In the case of attachments to `UsdGeomXformable` prims (i.e. `type1` is `'xform'`), `indices1` is empty.
 - `coords0`, `coords1`: Specify the local coordinates of the attachment sites relative to the corresponding site geometry feature described by `type0`, `indices0` or `type1`, `indices1` respectively. See the table below for how the coordinates are interpreted.
-- `stiffness`, `damping`: Specify the constitutive properties of all attachments in the set. The stiffness attribute specifies the strength of the attachment in units of force/area, and has a range of [0, inf), while a value of inf (simulator default) implies that the simulator should treat the constraint as hard if it is possible. The damping attribute only applies if the constraint isn't hard. Its specified in units of mass/second, has a range of [0, inf), and a fallback value 0.
+- `stiffness`, `damping`: Specify the constitutive properties of all attachments in the set. The stiffness attribute specifies the strength of the attachment in units of force/area, and has a range of [0, inf), while its fallback value of inf implies that the simulator should treat the constraint as hard if it is possible. The damping attribute only applies if the constraint isn't hard. Its specified in units of mass/second, has a range of [0, inf), and a fallback value 0.
 
 The following table shows the compatibility between sources and site types, as well as how indices and coordinates are interpreted.
 


### PR DESCRIPTION
<!--
Draft PR description for the deformables PR (head: physics-deformables, base: main).
This is the LEAN version — a synopsis only; the full rationale lives in the proposal's Design Notes, which is where line-level review happens.
NOTE: this file is scratch. The PR description lives in GitHub's PR form, not the repo — do not commit it.
-->

### Description of Proposal

#### Summary

This proposal extends `UsdPhysics` with a basic, interoperable, backwards-compatible set of abstractions for **deformable body dynamics** — the elastic deformation of volumes, surfaces (e.g. cloth, shells), and curves (e.g. hair, rods). It mirrors the design philosophy of the 2021 rigid body schema (real-world material quantities, unit independence, properties on materials, adding APIs to existing classes over introducing new prims) and interoperates with rigid bodies so both can coexist in a stage.

#### Problem statement

USD has expressed rigid body physics since 2021, but there is no standard way to represent deformable content — the materials, simulation geometry, rest shape, collision, embedding, and attachment data needed to simulate it. This proposal defines those abstractions so deformable content can be exchanged across DCCs and simulators, the way rigid bodies are today.

#### Scope

In scope (new `UsdPhysics` types — see the proposal for the full list and details):

- A shared `UsdPhysicsBodyAPI` (rigid body refactor, backwards compatible).
- Deformable materials and simulation APIs for volume, surface, and curve deformables.
- Deformable bodies, simulation geometry, and rest shape.
- Collision and graphics geometries, and bind poses for geometry embedding.
- Material assignment and mass distribution.
- Kinematic deformables, attachments, and element collision filtering.

Out of scope (left for future extensions):

- Plastic deformation.
- Per-point / per-element kinematic state.
- Direct rotational coupling in attachments.
- Continuous (primvar-driven) material variation.

#### Reference links

- Rendered proposal: [wp_deformable_physics.md](https://github.com/aousd/OpenUSD-proposals/blob/physics-deformables/proposals/physics_deformables/wp_deformable_physics.md)
- Folder overview: [README.md](https://github.com/aousd/OpenUSD-proposals/blob/physics-deformables/proposals/physics_deformables/README.md)
- Developed in the AOUSD Physics Working Group ([aousd.org](https://aousd.org)); builds on the existing `UsdPhysics` rigid body schema (2021).

_Design rationale, risks, and alternatives considered are documented inline in the proposal's Design Notes._

### Supporting Materials

The proposal includes `.usda` examples throughout and embeds illustrative figures under [`proposals/physics_deformables/images/`](https://github.com/aousd/OpenUSD-proposals/tree/physics-deformables/proposals/physics_deformables/images).

### Contributing

- [x] I agree to and accept the [Supplemental Terms](https://graphics.pixar.com/usd/release/contributing_supplemental.html).
